### PR TITLE
Fix broken links

### DIFF
--- a/contacting-us.md
+++ b/contacting-us.md
@@ -25,7 +25,7 @@ For community related questions, you can use [community@fair-dom.org](mailto:com
 
 Bugs and feature requests can be reported through [GitHub Issues](https://fair-dom.org/issues).
 
-For more details and guidelines please visit [Reporting Bugs and raising Feature Requests](/tech/reporting-bugs-and-features.html).
+For more details and guidelines please visit [Reporting Bugs and raising Feature Requests]({{ site.baseurl }}/tech/reporting-bugs-and-features.html).
 
 ## Google groups
 

--- a/get-seek.md
+++ b/get-seek.md
@@ -13,17 +13,17 @@ redirect_from: "/get_seek.html"
 
 ### Installation
 
-For details on how to install FAIRDOM-SEEK please refer to our [Installation Guide](tech/install).
+For details on how to install FAIRDOM-SEEK please refer to our [Installation Guide]({{ site.baseurl }}/tech/install).
 
-For details on how to upgrade an existing FAIRDOM-SEEK installation please refer to our [Upgrade Guide](tech/upgrading).
+For details on how to upgrade an existing FAIRDOM-SEEK installation please refer to our [Upgrade Guide]({{ site.baseurl }}/tech/upgrading).
 
 ### Docker
 
-FAIRDOM-SEEK can also be deployed using [Docker](https://docker.com), for which we provide Docker images. Please read our [Docker guide](/tech/docker).
+FAIRDOM-SEEK can also be deployed using [Docker](https://docker.com), for which we provide Docker images. Please read our [Docker guide]({{ site.baseurl }}/tech/docker).
 
 ### Changes
 
-To review changes and new features introduced between FAIRDOM-SEEK versions please visit our [Change Log](/tech/releases/).
+To review changes and new features introduced between FAIRDOM-SEEK versions please visit our [Change Log]({{ site.baseurl }}/tech/releases/).
 
 
 

--- a/help/archived.md
+++ b/help/archived.md
@@ -4,57 +4,60 @@ title: Archived help and guidelines
 <!--
 ## User Guide
 
-[SEEK user documentation](user-guide/index.html)
+[SEEK user documentation]({{ site.baseurl }}/user-guide/index.html)
 
 ## API
 
-[API introduction](user-guide/api.html)
+[API introduction]({{ site.baseurl }}/user-guide/api.html)
 
 ## Guidelines for Data and Model Annotation in SEEK
 
-[Metadata Guidelines](metadata-guidelines.html)
+[Metadata Guidelines]({{ site.baseurl }}/metadata-guidelines.html)
 
-[A Quick Guide to Using the ISA Structure](isa-guide.html)
+[A Quick Guide to Using the ISA Structure]({{ site.baseurl }}/isa-guide.html)
 
-[ISA Best Practice](isa-best-practice.html)
+[ISA Best Practice]({{ site.baseurl }}/isa-best-practice.html)
 
-[Transcriptomics Guidelines](transcriptomics-guidelines.html)
+[Transcriptomics Guidelines]({{ site.baseurl }}/transcriptomics-guidelines.html)
 
-[Proteomics Guidelines](proteomics-guidelines.html)
+[Proteomics Guidelines]({{ site.baseurl }}/proteomics-guidelines.html)
 
 
 ## Guidelines for using Community Resources and Controlled Vocabularies
 
-[Controlled Vocabularies and Ontologies](controlled-vocabularies.html)
+[Controlled Vocabularies and Ontologies]({{ site.baseurl }}/controlled-vocabularies.html)
 
 ## JERM Templates for use in SEEK
 
-[JERM Templates](templates.html)
+[JERM Templates]({{ site.baseurl }}/templates.html)
 
 ## FAQ
 
-[Frequently Asked Questions](faq.html)
+[Frequently Asked Questions]({{ site.baseurl }}/faq.html)
 -->
-The FAIRDOM-SEEK help and guidelines are written for users of any FAIRDOM-SEEK instance. 
+The FAIRDOM-SEEK help and guidelines are written for users of any FAIRDOM-SEEK instance.
 
-{% include callout.html type="important" content="Please see the [user guide](/help/user-guide) for the latest help." %}
+{% assign guide_url = site.baseurl | append: '/help/user-guide' %}
+{% assign callout_content = "Please see the [user guide](" | append: guide_url | append: ") for the latest help." %}
+{% include callout.html type="important" content=callout_content %}
+
 
 <!--
 ## Latest help: User Guide
 
-- [<i class="fa-solid fa-user-group fa-1x"></i> <i class="fa-solid fa-book fa-1x"></i> User Guide](/help/user-guide)
-- [API Introduction](/help/user-guide/api)
+- [<i class="fa-solid fa-user-group fa-1x"></i> <i class="fa-solid fa-book fa-1x"></i> User Guide]({{ site.baseurl }}/help/user-guide)
+- [API Introduction]({{ site.baseurl }}/help/user-guide/api)
 -->
 
 ## Archived pages
 
-All other pages have been archived and may not provide current information. 
-They are organised by sections on the left menu and cover Metadata, ISA, and controlled vocabularies. You can also search at the top-right of any page. 
+All other pages have been archived and may not provide current information.
+They are organised by sections on the left menu and cover Metadata, ISA, and controlled vocabularies. You can also search at the top-right of any page.
 
 <!--
-## Contributing 
+## Contributing
 
 There are many ways in which you can contribute to the SEEK software, these documents or our [FAIRDOM](https://fair-dom.org) project.
 
-If you are interested in contributing please visit our [Contributors guide](/contributing).
+If you are interested in contributing please visit our [Contributors guide]({{ site.baseurl }}/contributing).
 -->

--- a/help/controlled-vocabularies.md
+++ b/help/controlled-vocabularies.md
@@ -3,13 +3,15 @@ title: Controlled vocabularies and ontologies
 redirect_from: "/controlled-vocabularies.html"
 ---
 
-{% include callout.html type="warning" content="This guide has been archived. Please see the [user guide](/help/user-guide) for the latest help." %}
+{% assign guide_url = site.baseurl | append: '/help/user-guide' %}
+{% assign callout_content = "Please see the [user guide](" | append: guide_url | append: ") for the latest help." %}
+{% include callout.html type="warning" content=callout_content %}
 
 {% include callout.html type="note" content="This guide refers to SEEK, but is also relevant for [FAIRDOMHUB](https://www.fairdomhub.org/), which is an instance of SEEK." %}
 
 We recommend SEEK users use identifiers from public databases and terms from community ontologies wherever possible when describing and annotating data and models. The following table shows the resources available for annotation by biological object category. These represent the most commonly used within System Biology.
 
-## Contributing 
+## Contributing
 SEEK documentation is a community driven activity, and we are always looking to expand. If you have any modifications you want to make to the list please send requests, or feedback to <community@fair-dom.org>.
 
 <table>
@@ -113,11 +115,11 @@ Accessing and navigating these resources can be difficult and time-consuming for
 
 ### RightField
 
-RightField (http://www.rightfield.org.uk) allows the easy annotation of excel spreadsheet data with terms from community ontologies. Relevant ranges of ontology terms can be embedded into spreadsheets in specific cells as simple drop-down lists. This allows consistent and standards-compliant annotation without the need to browse or navigate the ontologies.   
-Multiple ontologies can be used in the same spreadsheet, and the sources of each term and the version of each ontology is automatically collected and recorded.   
+RightField (http://www.rightfield.org.uk) allows the easy annotation of excel spreadsheet data with terms from community ontologies. Relevant ranges of ontology terms can be embedded into spreadsheets in specific cells as simple drop-down lists. This allows consistent and standards-compliant annotation without the need to browse or navigate the ontologies.
+Multiple ontologies can be used in the same spreadsheet, and the sources of each term and the version of each ontology is automatically collected and recorded.
 A collection of SysMO templates have already been RightField-enabled. These templates are available for download from the templates page and from the SysMO-DB project in the SEEK.
 
 ### JWS OneStop
 
-OneStop assists with model annotation and publishing. It is a one-stop-shop for producing a MIRIAM-compliant, annotated model in SBML. OneStop extracts the names used for species and reactions in an uploaded model and uses these names to search public databases for the official terms and MIRIAM identifiers. It uses the Semantic SBML web service (http://semanticsbml.org/) for searching and returns a list of possible matches that the modellers can select from. This ensures the accuracy of each annotation whilst providing an easy mechanism for identifying possible matches.   
-In addition to annotations, OneStop also provides editing and validation functionality as well as automatically exporting models in SBGN.  
+OneStop assists with model annotation and publishing. It is a one-stop-shop for producing a MIRIAM-compliant, annotated model in SBML. OneStop extracts the names used for species and reactions in an uploaded model and uses these names to search public databases for the official terms and MIRIAM identifiers. It uses the Semantic SBML web service (http://semanticsbml.org/) for searching and returns a list of possible matches that the modellers can select from. This ensures the accuracy of each annotation whilst providing an easy mechanism for identifying possible matches.
+In addition to annotations, OneStop also provides editing and validation functionality as well as automatically exporting models in SBGN.

--- a/help/faq.md
+++ b/help/faq.md
@@ -3,15 +3,17 @@ title: Frequently Asked Questions
 redirect_from: "/faq.html"
 ---
 
-{% include callout.html type="warning" content="This guide has been archived. Please see the [user guide](/help/user-guide) for the latest help." %}
+{% assign guide_url = site.baseurl | append: '/help/user-guide' %}
+{% assign callout_content = "This guide has been archived. Please see the [user guide](" | append: guide_url | append: ") for the latest help." %}
+{% include callout.html type="warning" content=callout_content %}
 
-Please see our general [Seek4Science FAQ](https://seek4science.org/faq) page for a list of frequently asked questions. 
+Please see our general [Seek4Science FAQ](https://seek4science.org/faq) page for a list of frequently asked questions.
 
 <!--
-## Contributing 
-If you want to contribute to the SEEK software please visit our [Contribution Guide](/contributing.html)
+## Contributing
+If you want to contribute to the SEEK software please visit our [Contribution Guide]({{ site.baseurl }}/contributing.html)
 
 If you want to contribute to the SEEK guides, templates, or website please contact <community@fair-dom.org> for more details.
 
 If you want to propose a workshop/tutorial/hack-day related to SEEK please also contact <community@fair-dom.org>.
--->  
+-->

--- a/help/isa-best-practice.md
+++ b/help/isa-best-practice.md
@@ -3,13 +3,16 @@ title: ISA best practice guide
 redirect_from: "/isa-best-practice.html"
 ---
 
-{% include callout.html type="warning" content="This guide has been archived. Please see the [user guide](/help/user-guide) for the latest help." %}
+{% assign guide_url = site.baseurl | append: '/help/user-guide' %}
+{% assign callout_content = "This guide has been archived. Please see the [user guide](" | append: guide_url | append: ") for the latest help." %}
+{% include callout.html type="warning" content=callout_content %}
+
 
 {% include callout.html type="note" content="This guide refers to SEEK, but is also relevant for [FAIRDOMHUB](https://www.fairdomhub.org/), which is an instance of SEEK." %}
 
-The ISA Infrastructure (Investigation, Study, Assay) is a general purpose framework for describing how experiments relate to one another. It describes both metadata (samples, characteristics, technologies, etc) and data (transcriptomics, proteomics etc), but the data itself is stored separately, and can therefore be as public or private as required. The ISA descriptions are visible to the rest of SEEK users.  
-The original purpose of the ISA infrastructure was to provide a common framework for relating multiple omics data and to provide a single mechanism for submission to omics data repositories (such as ArrayExpress for Microarray data, or PRIDE, for proteomics data). SEEK data often involves omics data and generally relies on the integration of multiple data types, so the ISA infrastructure will provide a mechanism for SEEK data export as well as providing a common framework for navigation.   
-For more information on the ISA community work, please see:  
+The ISA Infrastructure (Investigation, Study, Assay) is a general purpose framework for describing how experiments relate to one another. It describes both metadata (samples, characteristics, technologies, etc) and data (transcriptomics, proteomics etc), but the data itself is stored separately, and can therefore be as public or private as required. The ISA descriptions are visible to the rest of SEEK users.
+The original purpose of the ISA infrastructure was to provide a common framework for relating multiple omics data and to provide a single mechanism for submission to omics data repositories (such as ArrayExpress for Microarray data, or PRIDE, for proteomics data). SEEK data often involves omics data and generally relies on the integration of multiple data types, so the ISA infrastructure will provide a mechanism for SEEK data export as well as providing a common framework for navigation.
+For more information on the ISA community work, please see:
 [http://isa-tools.org/](http://isa-tools.org/)
 
 
@@ -18,14 +21,14 @@ For more information on the ISA community work, please see:
 There are many ways to describe your projects and the relationships between the different work-packages and research topics. The following guidelines provide a general description of the ISA Infrastructure and examples of how this may fit with your SEEK project. We use examples from the [Bioinvestigation Index (BII)](https://github.com/ISA-tools/BioInvIndex), which is a public database of ISA compliant data. We also use examples already available in SEEK
 
 * **Investigation:** a high level description of the area and the main aims of a project
-    * In SEEK, this may be the overall aims as stated on your grant.   
+    * In SEEK, this may be the overall aims as stated on your grant.
 If your project has several subprojects that do not share any data, you should define an investigation for each.
     * **BII Example:** Growth control of the eukaryote cell: a systems biology study in yeast
     * **SEEK Example** Analysis of Central Carbon Metabolism of Sulfolobus solfataricus under varying temperatures
 * **Study:** a particular biological hypothesis or analysis
-    * In SEEK, these studies may contain only experimental assays, only modelling analyses, only informatics analyses,   
+    * In SEEK, these studies may contain only experimental assays, only modelling analyses, only informatics analyses,
 or a mixture of all
-    * **BII Example:** Study of the impact of changes in flux on the transcriptome, proteome, endometabolome and exometabolome   
+    * **BII Example:** Study of the impact of changes in flux on the transcriptome, proteome, endometabolome and exometabolome
 of the yeast Saccharomyces cerevisiae under different nutrient limitations
     * **SEEK Example:** Comparison of S. solfataricus grown at 70 and 80 degrees
 * **Assay:** specific, individual experiments required to be undertaken together in order to address the study hypotheses.
@@ -44,35 +47,35 @@ A short guide to creating a new ISA file
 
 ### Investigation
 
-**Title** – The name of the investigation. All assets should have a title  
-**Description** – free text describing the purpose of the investigation  
+**Title** – The name of the investigation. All assets should have a title
+**Description** – free text describing the purpose of the investigation
 **Project** – The project that the investigation belongs to. All assets should be associated with a project
 
 ### Study
 
-**Title** – The name of the Study. All assets should have a title  
-**Description** – free text describing the purpose of the study  
-**Person Responsible** – the creator of the study description  
-**Experimentalists** – other scientists involved in any of the work in the study. If they are in your instance of SEEK, please give their SEEK ID, so we can link to their profiles in SEEK. If they are not in SEEK, their names will still be displayed, but not linked. People's involvement can also be inferred from anyone named in included assays.  
-**Project** – The project that the study belongs to. All assets should be associated with a project  
+**Title** – The name of the Study. All assets should have a title
+**Description** – free text describing the purpose of the study
+**Person Responsible** – the creator of the study description
+**Experimentalists** – other scientists involved in any of the work in the study. If they are in your instance of SEEK, please give their SEEK ID, so we can link to their profiles in SEEK. If they are not in SEEK, their names will still be displayed, but not linked. People's involvement can also be inferred from anyone named in included assays.
+**Project** – The project that the study belongs to. All assets should be associated with a project
 **Investigation title** – The name of the investigation the study belongs to.
 
 ### Assay
 
-**Assay Title** – The name of the assay that the asset links to.   
-**Assay type** – The controlled vocabulary term describing the assay classification  
-If you cannot find a suitable Assay Type term, then you can generate your own.   
-**Technology type** – The controlled vocabulary term describing the technology used in the assay  
-If you cannot find a suitable Technology Type term then you can generate your own.  
-**Study title** – The name of the study the assay belongs to. An assay can belong to more than one study  
-**Organism** The name of the organism being studied with this asset. If uploading through SEEK, organism names are provided as a drop-down list  
-**Strain** The name of the particular strain being studied  
-**WT/Mutant** – Specifies whether this strain is wild-type or mutant  
-**Genotype** – a brief text description of the genotype  
-**Phenotype** – a brief text description of the phenotype  
-**Culture Growth** – This describes how the culture was grown for this assay. You can choose values from a drop-down list when adding new assays directly to SEEK  
-**Data File Titles** – the title of one or many data files produced during this assay  
-**SOP Titles** – the title of one or many SOPs used to execute this assay  
+**Assay Title** – The name of the assay that the asset links to.
+**Assay type** – The controlled vocabulary term describing the assay classification
+If you cannot find a suitable Assay Type term, then you can generate your own.
+**Technology type** – The controlled vocabulary term describing the technology used in the assay
+If you cannot find a suitable Technology Type term then you can generate your own.
+**Study title** – The name of the study the assay belongs to. An assay can belong to more than one study
+**Organism** The name of the organism being studied with this asset. If uploading through SEEK, organism names are provided as a drop-down list
+**Strain** The name of the particular strain being studied
+**WT/Mutant** – Specifies whether this strain is wild-type or mutant
+**Genotype** – a brief text description of the genotype
+**Phenotype** – a brief text description of the phenotype
+**Culture Growth** – This describes how the culture was grown for this assay. You can choose values from a drop-down list when adding new assays directly to SEEK
+**Data File Titles** – the title of one or many data files produced during this assay
+**SOP Titles** – the title of one or many SOPs used to execute this assay
 
-## Contributing 
+## Contributing
 SEEK documentation is a community driven activity. If you have any modifications you want to make to the guidelines please send requests, or feedback to <community@fair-dom.org>.

--- a/help/isa-guide.md
+++ b/help/isa-guide.md
@@ -3,13 +3,15 @@ title: A Quick guide to using ISA in SEEK
 redirect_from: "/isa-guide.html"
 ---
 
-{% include callout.html type="warning" content="This guide has been archived. Please see the [user guide](/help/user-guide) for the latest help." %}
+{% assign guide_url = site.baseurl | append: '/help/user-guide' %}
+{% assign callout_content = "This guide has been archived. Please see the [user guide](" | append: guide_url | append: ") for the latest help." %}
+{% include callout.html type="warning" content=callout_content %}
 
 {% include callout.html type="note" content="This guide refers to SEEK, but is also relevant for [FAIRDOMHUB](https://www.fairdomhub.org/), which is an instance of SEEK." %}
 
-ISA stands for Investigations, Studies and Assays. It is the structure developed by the ISA-TAB community (http://isacommons.org/) and adopted by the SEEK to help you describe your data, experiments and models.  
-In SEEK, you can upload or link to any data, models or protocols from your projects, but they don't normally exist in isolation. ISA provides a framework for expressing how the work in your projects fits together. For example, you may have transcriptomics, proteomics and metabolomics data which was all created to address the same biological problem.   
-ISA also allows you to associate your data to the SOPs that were used to create them. For models, it allows linkage to construction or validation data sets. This makes it easier for others to interpret your results, or to repeat or validate your results when required.   
+ISA stands for Investigations, Studies and Assays. It is the structure developed by the ISA-TAB community (http://isacommons.org/) and adopted by the SEEK to help you describe your data, experiments and models.
+In SEEK, you can upload or link to any data, models or protocols from your projects, but they don't normally exist in isolation. ISA provides a framework for expressing how the work in your projects fits together. For example, you may have transcriptomics, proteomics and metabolomics data which was all created to address the same biological problem.
+ISA also allows you to associate your data to the SOPs that were used to create them. For models, it allows linkage to construction or validation data sets. This makes it easier for others to interpret your results, or to repeat or validate your results when required.
 The aim of using the ISA structure is to ensure a complete record of the experiment and associated assets is available and accessible to other project members in a standard format.
 
 ## Investigations, studies and assays defined
@@ -22,25 +24,25 @@ The following describes the purpose of each 'layer' in the structure, using exam
 * **Study:** a particular biological hypothesis, which you are planning to test in various ways, using various techniques, which could be experimental, informatics, modelling, or a mixture
 * BII Example: Study of the impact of changes in flux on the transcriptome, proteome, endometabolome and exometabolome of the yeast Saccharomyces cerevisiae under different nutrient limitations
 * SEEK Example: Comparison of S. solfataricus grown at 70 and 80 degrees
-* **Assay:** specific, individual experiments, measurements, or modelling tasks  
+* **Assay:** specific, individual experiments, measurements, or modelling tasks
 In SEEK, this may be a microarray experiment, or a flux balance analysis, for example
-* BII Example:   
-Transcriptional profiling  
+* BII Example:
+Transcriptional profiling
 DNA Microarray
-* SEEK Example:   
-Comparison of transcriptome 70 and 80c (Cdna microarray)  
-Comparison of proteome at 70 and 80c (Protein expression profiling)  
+* SEEK Example:
+Comparison of transcriptome 70 and 80c (Cdna microarray)
+Comparison of proteome at 70 and 80c (Protein expression profiling)
 Intracellular metabolomics of s. solfataricus at 70 and 80c (Metabolomics)
 
 ## Viewing associations between SEEK assets
 
 In SEEK, the ISA structure is displayed graphically, so you can see at a glance what items are associated with one another
 
-![](/images/ISAUpperLevel.png){:.screenshot}
+![]({{ site.baseurl }}/images/ISAUpperLevel.png){:.screenshot}
 
 The figure above shows the Investigation &quot;Central Carbon Metabolism of Sulfolobus solfataricus&quot;  has one study, which in turn contains two different assays. If we zoom in on one particular assay, the &quot;Model Validation Gluconeogenesis in S. solfataricus&quot;, we can see the SEEK downloadable assets it is associated with.
 
-![](/images/ISADataModel.png){:.screenshot}
+![]({{ site.baseurl }}/images/ISADataModel.png){:.screenshot}
 
 In this case, the Assay is not a laboratory experiment, but a modelling task. This is key point to note when using ISA, the assays refer, in essence, to experiments, which means they can be laboratory analysis, modelling analysis, data analysis and more. In this example the assay has data files, a model, and a publication associated with it.
 It is possible to associate data files, models, and other SEEK assets with more than one assay if necessary.
@@ -51,13 +53,12 @@ You can link assets to ISA parts, or vice versa, so it doesn't matter which you 
 
 ## Starting with your data
 
-We recommend using a JERM template to describe your data wherever available. We have some available templates: [JERM Templates](templates.html)  
+We recommend using a JERM template to describe your data wherever available. We have some available templates: [JERM Templates]({{ site.baseurl }}/templates.html)
 If there is not a specific template for your type of data, consider using the general JERM master template. This template contains all the required JERM metadata elements, but not necessarily any technology-specific extensions.  If you have your data in any other format, you can still upload it to SEEK, but indexing will be limited, so subsequent searches will also be limited. Our templates are community driven, which means our users help us keep them up to date. If you generate a new template, or make changes to a template to bring it up to date, it would be great if you could send us the updates and a brief description so we can make them available for others to use. Contact us <community@fair-dom.org>.
 
-When uploading your data, you will be asked wish assay(s) it is associated with. If you have already described the assay in the SEEK, you can find it from the drop-down list and link it, if you have not yet described your assay, you can leave this step out for the time-being. If your data is JERM compliant, many of the metadata elements in the upload form are the same as those in the first JERM metadata sheet. Soon, these elements will be automatically populated from your file, but for now, you will be asked to specify them in the web interface.  
-Once you have uploaded your data, you can create a new assay if necessary and link it back to your data. New assays can be associated with pre-existing Studies and Investigations, or new ones can be created as required.   
+When uploading your data, you will be asked wish assay(s) it is associated with. If you have already described the assay in the SEEK, you can find it from the drop-down list and link it, if you have not yet described your assay, you can leave this step out for the time-being. If your data is JERM compliant, many of the metadata elements in the upload form are the same as those in the first JERM metadata sheet. Soon, these elements will be automatically populated from your file, but for now, you will be asked to specify them in the web interface.
+Once you have uploaded your data, you can create a new assay if necessary and link it back to your data. New assays can be associated with pre-existing Studies and Investigations, or new ones can be created as required.
 If you upload data without linking it to the ISA structure, you won't be able to link it to models or SOPs.
 
-## Contributing 
+## Contributing
 SEEK documentation is a community driven activity. If you have any modifications you want to make to the guide please send requests, or feedback to <community@fair-dom.org>.
-  

--- a/help/jerm.md
+++ b/help/jerm.md
@@ -3,7 +3,9 @@ title: JERM (Just Enough Results Model)
 redirect_from: "/jerm.html"
 ---
 
-{% include callout.html type="warning" content="This guide has been archived. Please see the [user guide](/help/user-guide) for the latest help." %}
+{% assign guide_url = site.baseurl | append: '/help/user-guide' %}
+{% assign callout_content = "This guide has been archived. Please see the [user guide](" | append: guide_url | append: ") for the latest help." %}
+{% include callout.html type="warning" content=callout_content %}
 
 {% include callout.html type="note" content="This guide refers to SEEK, but is also relevant for [FAIRDOMHUB](https://www.fairdomhub.org/), which is an instance of SEEK." %}
 

--- a/help/metadata-guidelines.md
+++ b/help/metadata-guidelines.md
@@ -4,93 +4,95 @@ redirect_from: "/metadata-guidelines.html"
 ---
 
 
-{% include callout.html type="warning" content="This guide has been archived. Please see the [user guide](/help/user-guide) for the latest help." %}
+{% assign guide_url = site.baseurl | append: '/help/user-guide' %}
+{% assign callout_content = "This guide has been archived. Please see the [user guide](" | append: guide_url | append: ") for the latest help." %}
+{% include callout.html type="warning" content=callout_content %}
 
 {% include callout.html type="note" content="This guide refers to SEEK, but is also relevant for [FAIRDOMHUB](https://www.fairdomhub.org/), which is an instance of SEEK." %}
 
 The more metadata you provide for your assets in the SEEK, the easier it is to find them and to compare them with other assets. If you provide assets with very little metadata, these will also be displayed (in accordance with access control policies set by you), but they may be hard to interpret for other people.
 
-In addition to SEEK data sharing guidelines, some types of data have minimum metadata requirements for publication, for example, microarray data must be MIAME compliant. Following the guidelines for SEEK metadata should ensure that when you come to publish, you have already met these requirements.   
+In addition to SEEK data sharing guidelines, some types of data have minimum metadata requirements for publication, for example, microarray data must be MIAME compliant. Following the guidelines for SEEK metadata should ensure that when you come to publish, you have already met these requirements.
 These guidelines outline what we recommend for SEEK.
 
 ## General SEEK metadata
 
-**Name** (of the data uploader). This is the person responsible for the data and responsible for setting sharing and dissemination policies. If more than one person was involved in the experiment, you can credit these people separately   
-**SEEK ID** – (Of the above person). This helps us identify each person within SEEK.   
-**Project** – The name of the project that the asset relates to. If you are uploading directly to SEEK and you are in more than one project in SEEK, it is important to specify. Typically, an asset will belong to only one project.  
-**Upload Date (yymmdd)**. This is the date of publication to SEEK rather than the date of the experiment. Depending on the system your project uses, we will try to automatically detect when changes are made to a file. Each upload will automatically receive its own timestamp when uploaded directly into SEEK  
-**Experiment Date (yymmdd)**. This is the date the experiment was performed  
-**Title** – a unique name for your asset file. If you upload manually, you will receive an error message if the file title is not unique within your project. If your asset is uploaded via a JERM Harvester without a title, you will receive an email notification.  
-**Version Number** – If your file replaces an existing file, the version number will help us pick this up. Keep it simple, versions should go up by integers.  
+**Name** (of the data uploader). This is the person responsible for the data and responsible for setting sharing and dissemination policies. If more than one person was involved in the experiment, you can credit these people separately
+**SEEK ID** – (Of the above person). This helps us identify each person within SEEK.
+**Project** – The name of the project that the asset relates to. If you are uploading directly to SEEK and you are in more than one project in SEEK, it is important to specify. Typically, an asset will belong to only one project.
+**Upload Date (yymmdd)**. This is the date of publication to SEEK rather than the date of the experiment. Depending on the system your project uses, we will try to automatically detect when changes are made to a file. Each upload will automatically receive its own timestamp when uploaded directly into SEEK
+**Experiment Date (yymmdd)**. This is the date the experiment was performed
+**Title** – a unique name for your asset file. If you upload manually, you will receive an error message if the file title is not unique within your project. If your asset is uploaded via a JERM Harvester without a title, you will receive an email notification.
+**Version Number** – If your file replaces an existing file, the version number will help us pick this up. Keep it simple, versions should go up by integers.
 **Names of other people involved** – many experiments involve multiple steps and multiple people. This metadata field allows you to give credit and attribution to all those involved
 
 ## ISA framework
-For more information on how the ISA Framework is implemented in SEEK please visit [A Quick Guide to Using the ISA Structure](isa-guide.html), for more information about ISAtab itself please visit http://isatab.sourceforge.net/format.html 
+For more information on how the ISA Framework is implemented in SEEK please visit [A Quick Guide to Using the ISA Structure](isa-guide.html), for more information about ISAtab itself please visit http://isatab.sourceforge.net/format.html
 
 ### Investigation
 
-**Title** – described above. All assets should have a title  
-**Description** – free text describing the purpose of the investigation  
+**Title** – described above. All assets should have a title
+**Description** – free text describing the purpose of the investigation
 **Project** – as described above. All assets should be associated with a project
 
 ### Study
 
-**Title** – as described above. All assets should have a title  
-**Description** – free text describing the purpose of the study  
-**Person Responsible** – the creator of the study description  
-**Experimentalists** – other scientists involved in any of the work in the study. If they are registered SEEK users, please give their SEEK ID, so we can link to their profiles in SEEK. If they are not registered in SEEK, their names will still be displayed, but not linked. People's involvement can also be inferred from anyone named in included assays.  
-**Project** – as described above. All assets should be associated with a project  
+**Title** – as described above. All assets should have a title
+**Description** – free text describing the purpose of the study
+**Person Responsible** – the creator of the study description
+**Experimentalists** – other scientists involved in any of the work in the study. If they are registered SEEK users, please give their SEEK ID, so we can link to their profiles in SEEK. If they are not registered in SEEK, their names will still be displayed, but not linked. People's involvement can also be inferred from anyone named in included assays.
+**Project** – as described above. All assets should be associated with a project
 **Investigation title** – The name of the investigation the study belongs to.
 
 ### Assay
 
-**Assay Title** – The name of the assay that the asset links to.   
-**Assay type** – The controlled vocabulary term describing the assay classification comes from the JERM ontology. Users can also describe their own.     
-**Technology type** – The controlled vocabulary term describing the technology used in the assay  
-Users can also describe their own.   
-**Study title** – The name of the study the assay belongs to. An assay can belong to more than one study  
-**Organism** The name of the organism being studied with this asset. If uploading through SEEK, organism names are provided as a drop-down list. Users can also describe their own.   
-**Strain** The name of the particular strain being studied  
-**WT/Mutant** – Specifies whether this strain is wild-type or mutant  
-**Genotype** – a brief text description of the genotype  
-**Phenotype** – a brief text description of the phenotype  
-**Culture Growth** – This describes how the culture was grown for this assay. You can choose values from a drop-down list when adding new assays directly to SEEK  
-**Data File Titles** – the title of one or many data files produced during this assay  
+**Assay Title** – The name of the assay that the asset links to.
+**Assay type** – The controlled vocabulary term describing the assay classification comes from the JERM ontology. Users can also describe their own.
+**Technology type** – The controlled vocabulary term describing the technology used in the assay
+Users can also describe their own.
+**Study title** – The name of the study the assay belongs to. An assay can belong to more than one study
+**Organism** The name of the organism being studied with this asset. If uploading through SEEK, organism names are provided as a drop-down list. Users can also describe their own.
+**Strain** The name of the particular strain being studied
+**WT/Mutant** – Specifies whether this strain is wild-type or mutant
+**Genotype** – a brief text description of the genotype
+**Phenotype** – a brief text description of the phenotype
+**Culture Growth** – This describes how the culture was grown for this assay. You can choose values from a drop-down list when adding new assays directly to SEEK
+**Data File Titles** – the title of one or many data files produced during this assay
 **SOP Titles** – the title of one or many SOPs used to execute this assay
 
 ## SEEK assets (data, models, SOPs, maps etc)
 
 ### Data
 
-**Title** – as described above  
-**Description** – free text to describe what the data is showing  
-**File Format** – how the data is stored, for example excel spreadsheet  
-**Factors Studied** – what experimental parameters did you alter in order to study the effects in the organism (e.g. changing the pH from 5 to 7)  
-**Measured Item** – what was measured in this data, e.g. concentration of glucose. Measured items should be named using controlled vocabulary terms wherever possible, for example, glucose has chEBI name glucose and chEBI ID CHEBI:17234  
+**Title** – as described above
+**Description** – free text to describe what the data is showing
+**File Format** – how the data is stored, for example excel spreadsheet
+**Factors Studied** – what experimental parameters did you alter in order to study the effects in the organism (e.g. changing the pH from 5 to 7)
+**Measured Item** – what was measured in this data, e.g. concentration of glucose. Measured items should be named using controlled vocabulary terms wherever possible, for example, glucose has chEBI name glucose and chEBI ID CHEBI:17234
 **Units** – how the measurements were taken, e.g. concentration in mmol, or mass in grams.
 
 ### Models
 
-**Filename/archive name** – the title of the asset  
-**Description** – free text to describe what the model is showing  
-**Model Type** – what kind of mathematical equations does your model contain e.g. ODE, algebraic  
-**Model Format** – e.g. SBML, CellML. If uploading directly through SEEK, you will be able to chose from a drop-down list  
-**Model Execution Environment and URL** – how do you run a simulation on your model? This field should provide a link to a tool or resource which would allow you to run your model  
+**Filename/archive name** – the title of the asset
+**Description** – free text to describe what the model is showing
+**Model Type** – what kind of mathematical equations does your model contain e.g. ODE, algebraic
+**Model Format** – e.g. SBML, CellML. If uploading directly through SEEK, you will be able to chose from a drop-down list
+**Model Execution Environment and URL** – how do you run a simulation on your model? This field should provide a link to a tool or resource which would allow you to run your model
 **Linking Models to Data** – this section allows you to specify how and where data files were used to a) construct your model b) validate your model, or c) record simulation results from your model. If you are uploading directly through SEEK, you can find the relevant files by searching a drop-down list.
 
 ### SOPs
 
-**Title** – as described above. All assets should have a title  
-**Description** – free text to describe what the SOP is used for  
-**Experimental conditions** – what was standardised and fixed in this experiment (e.g. concentration of nutrients, pH, temperature). If you are uploading directly through SEEK, you can chose from a drop-down list  
+**Title** – as described above. All assets should have a title
+**Description** – free text to describe what the SOP is used for
+**Experimental conditions** – what was standardised and fixed in this experiment (e.g. concentration of nutrients, pH, temperature). If you are uploading directly through SEEK, you can chose from a drop-down list
 **Units** – how the measurements were taken e.g. concentration in mmol or mass in grams.
 
 ### Publications
 
-**PubmedID or DOI** – the SEEK can extract publication abstracts from PubMed, when supplied with a PubmedID. When the paper abstract is retrieved, you can verify which people from a drop-down list are authors from within the consortium, so that we can link to their profile.  
+**PubmedID or DOI** – the SEEK can extract publication abstracts from PubMed, when supplied with a PubmedID. When the paper abstract is retrieved, you can verify which people from a drop-down list are authors from within the consortium, so that we can link to their profile.
 Publications can be linked to other assets (data, models, SOPs) to allow you to use the SEEK as a supplementary data store.
 
-**Attribution** – Some assets are based on others, for example, a model may use data from an experimental assay, or a SOP may be a modified version of another. The attribution section allows you to specify when this is the case 
+**Attribution** – Some assets are based on others, for example, a model may use data from an experimental assay, or a SOP may be a modified version of another. The attribution section allows you to specify when this is the case
 
-## Contributing 
+## Contributing
 SEEK documentation is a community driven activity. If you have any modifications you want to make to the guidelines please send requests, or feedback to <community@fair-dom.org>.

--- a/help/proteomics-guidelines.md
+++ b/help/proteomics-guidelines.md
@@ -4,7 +4,9 @@ redirect_from: "/proteomics-guidelines.html"
 ---
 
 
-{% include callout.html type="warning" content="This guide has been archived. Please see the [user guide](/help/user-guide) for the latest help." %}
+{% assign guide_url = site.baseurl | append: '/help/user-guide' %}
+{% assign callout_content = "This guide has been archived. Please see the [user guide](" | append: guide_url | append: ") for the latest help." %}
+{% include callout.html type="warning" content=callout_content %}
 
 {% include callout.html type="note" content="This guide refers to SEEK, but is also relevant for [FAIRDOMHUB](https://www.fairdomhub.org/), which is an instance of SEEK." %}
 
@@ -28,8 +30,7 @@ The associated examples are templates for Mass Spectrometry experiments. These h
 
 Embedded in the spreadsheet are some macros that will help you annotate your data with terms from controlled vocabularies where appropriate.
 
-## Contributing 
+## Contributing
 SEEK documentation is a community driven activity. If you have any modifications you want to make to the guidelines please send requests, or feedback to <community@fair-dom.org>.
 
 [1]: http://www.ebi.ac.uk/pride/
-  

--- a/help/templates.md
+++ b/help/templates.md
@@ -4,22 +4,24 @@ redirect_from: "/templates.html"
 ---
 
 
-{% include callout.html type="warning" content="This guide has been archived. Please see the [user guide](/help/user-guide) for the latest help." %}
+{% assign guide_url = site.baseurl | append: '/help/user-guide' %}
+{% assign callout_content = "This guide has been archived. Please see the [user guide](" | append: guide_url | append: ") for the latest help." %}
+{% include callout.html type="warning" content=callout_content %}
 
 SEEK have been developing a collection of JERM templates to facilitate standard formats for sharing the same kinds of data through the consortium. This page lists the current templates available, although we are always looking to update and add to them with help from the community.
 
-## Contributing 
+## Contributing
 SEEK templates are a community driven activity. If you have any updates, modifications or new templates you want to include for other to use, or if you just want to send feedback, then you can contact us at <community@fair-dom.org>.
 
 #### SOPs
 
-* [Nature Protocols Format for SOPs](/attachments/NatureProtocolsFormat.doc)
+* [Nature Protocols Format for SOPs]({{ site.baseurl }}/attachments/NatureProtocolsFormat.doc)
 
 #### Data
 
-* [Master Template](https://fairdomhub.org/data_files/927)  
+* [Master Template](https://fairdomhub.org/data_files/927)
 
-This is the general format for all SEEK templates. Each spreadsheet has multiple sheets, defining experimental metadata, organims/samples, data and optional sheets for instrument descriptions and results.  
+This is the general format for all SEEK templates. Each spreadsheet has multiple sheets, defining experimental metadata, organims/samples, data and optional sheets for instrument descriptions and results.
 This template can be refined and/or extended to cater more specifically for different data types.
 
 ##### Metabolomics
@@ -32,36 +34,35 @@ This is a JERM compliant template for general use in metabolomics experiments
 
 ###### General Transcriptomics Templates
 
-* [General Chip-chip Array](https://fairdomhub.org/data_files/931)  
-A JERM compliant template based on a template taken from [GEO][3]  
-
-* [RT-PCR](https://fairdomhub.org/data_files/930)  
+* [General Chip-chip Array](https://fairdomhub.org/data_files/931)
 A JERM compliant template based on a template taken from [GEO][3]
 
-* [Gene Expression ArrayExpress](https://fairdomhub.org/data_files/8)  
-A JERM compliant template based on the MAGE-TAB ArrayExpress format (metadata only)  
+* [RT-PCR](https://fairdomhub.org/data_files/930)
+A JERM compliant template based on a template taken from [GEO][3]
+
+* [Gene Expression ArrayExpress](https://fairdomhub.org/data_files/8)
+A JERM compliant template based on the MAGE-TAB ArrayExpress format (metadata only)
 
 ###### Affymetrix
 
-* [3’ or Whole Gene Expression array](https://fairdomhub.org/data_files/928)  
-A JERM compliant template based on a template taken from [GEO][3]  
+* [3’ or Whole Gene Expression array](https://fairdomhub.org/data_files/928)
+A JERM compliant template based on a template taken from [GEO][3]
 
-* [Chip-chip Array](https://fairdomhub.org/data_files/929)  
+* [Chip-chip Array](https://fairdomhub.org/data_files/929)
 A JERM compliant template for Chip-chip data based on a template taken from [GEO][3]
 
 ###### Nimblegen
 
-* [Gene Expression](https://fairdomhub.org/data_files/933)  
-A JERM compliant template based on a template taken from [GEO][3]  
+* [Gene Expression](https://fairdomhub.org/data_files/933)
+A JERM compliant template based on a template taken from [GEO][3]
 
 ##### Proteomics
 
-* [Mass Spec JERM](https://fairdomhub.org/data_files/932)  
+* [Mass Spec JERM](https://fairdomhub.org/data_files/932)
 This MIAPE template was adapted from a template offered by the [PRIDE database][5] to conform to the SEEK JERM format. For proteomics data, the "Instrument" sheet is mandatory.
 
-* [Gel Electrophoresis](https://fairdomhub.org/data_files/938)  
+* [Gel Electrophoresis](https://fairdomhub.org/data_files/938)
 This is a MIAPE-GE template for use with 2D gel data
 
 [3]: http://www.ncbi.nlm.nih.gov/geo/
 [5]: http://www.ebi.ac.uk/pride/
-  

--- a/help/transcriptomics-guidelines.md
+++ b/help/transcriptomics-guidelines.md
@@ -3,7 +3,9 @@ title: "Transcriptomics: Guidelines for SEEK templates"
 redirect_from: "/transcriptomics-guidelines.html"
 ---
 
-{% include callout.html type="warning" content="This guide has been archived. Please see the [user guide](/help/user-guide) for the latest help." %}
+{% assign guide_url = site.baseurl | append: '/help/user-guide' %}
+{% assign callout_content = "This guide has been archived. Please see the [user guide](" | append: guide_url | append: ") for the latest help." %}
+{% include callout.html type="warning" content=callout_content %}
 
 {% include callout.html type="note" content="This guide refers to SEEK, but is also relevant for [FAIRDOMHUB](https://www.fairdomhub.org/), which is an instance of SEEK." %}
 
@@ -15,16 +17,16 @@ For SEEK, we recommend you use MAGE-TAB templates for transcriptomics data. We h
 
 There are several parts to a MAGE-TAB file. These parts can be represented as separate files, or separate worksheets in excel. MAGE-TAB consists of:
 
-**IDF – Investigation Description Format**  
+**IDF – Investigation Description Format**
 This worksheet is an overview of the experiment, factors studied, protocols, publication information and contact details.
 
-**SDRF – Sample and Data Relationship Format**  
+**SDRF – Sample and Data Relationship Format**
 This worksheet details the links between sample and data, it can include information about the source (e.g. organism rat), the sample (e.g. rat liver), extracts (e.g. total RNA), labelled extract (e.g. synthetic DNA), hybridisations (e.g. a reference on the Array as defined by the ADF), raw data (e.g. a reference to a raw data file), normalisation (e.g. a reference to normalised data file), derived array data files (e.g. a reference to a derived data file, or file matrix)
 
-**Raw Data and Processed Data**  
+**Raw Data and Processed Data**
 These worksheets hold the actual and derived data values
 
-**ADF – Array Design Format (optional)**  
+**ADF – Array Design Format (optional)**
 This worksheet provides the array-level annotation for the experiment, relating the row-level identifiers in the data files to biological sequence annotation.
 
 There are a detailed [set of help pages and examples provided by the MGED community][1]
@@ -35,13 +37,13 @@ There are also tools to help you construct MAGE-TAB templates on the web. For ex
 
 ### IDF
 
-Many of the personal details in the IDF sheet can be automatically extracted from your SEEK profile. If you add your SEEK ID as an additional field (called SEEK ID), we can extract all your personal details from your profile so there is no need to complete these personal details fields.   
-Similarly, you can refer to protocols (SOPs in SEEK) by their SEEK ID, and we can automatically extract their name and brief description.  
+Many of the personal details in the IDF sheet can be automatically extracted from your SEEK profile. If you add your SEEK ID as an additional field (called SEEK ID), we can extract all your personal details from your profile so there is no need to complete these personal details fields.
+Similarly, you can refer to protocols (SOPs in SEEK) by their SEEK ID, and we can automatically extract their name and brief description.
 This worksheet also contains fields to link to publications. In many cases, data could be shared in SEEK before publication. If so, please leave these fields blank, but do not remove them.
 
 ### SDRF
 
-This file links the sample and source information to the data files and their locations.  
+This file links the sample and source information to the data files and their locations.
 The "protocol" columns will normally be followed by "factor value" columns. Again, we can extract these from the experimental conditions and factors studies sections of SEEK where you are referring to a SOP already submitted.
 
 ### Raw data and processed data
@@ -58,7 +60,7 @@ If your processed data maps to the identifier in your array design, you can crea
 
 This worksheet is necessary when submitting your array data to a public repository, but it is optional for SEEK. It is a physical description of the array. Many commercial and academic array designs have already been submitted to ArrayExpress, so you could simply reference your design from ArrayExpress. Affymetrix, Agilent, Illumina, Nimblegen and Sanger array designs have already been submitted and can be explored [here][5]
 
-## Contributing 
+## Contributing
 SEEK documentation is a community driven activity. If you have any modifications you want to make to the guidelines please send requests, or feedback to <community@fair-dom.org>.
 
 [1]: http://tab2mage.sourceforge.net/docs/magetab_docs.html
@@ -66,4 +68,3 @@ SEEK documentation is a community driven activity. If you have any modifications
 [3]: https://github.com/ISA-tools/ISAcreator
 [4]: http://tab2mage.sourceforge.net/docs/datafiles.html
 [5]: http://www.ebi.ac.uk/microarray-as/aer/entry
-  

--- a/help/user-guide/aai.md
+++ b/help/user-guide/aai.md
@@ -34,6 +34,6 @@ which outlines what personal data will be provided by LS Login to the SEEK insta
 At a minimum, the identifier must be provided, or login is not possible. Any other information is used solely to
 populate fields in your SEEK profile.
 
-If this is your first time logging in via LS Login, you will be directed to create a new "Profile". For guidance on how to do this, see [Registering in SEEK]({{ site.baseurl }}/registering#new-profile). Some fields such as your name and email address may already be populated with information provided by your institution.
+If this is your first time logging in via LS Login, you will be directed to create a new "Profile". For guidance on how to do this, see [Registering in SEEK](registering#new-profile). Some fields such as your name and email address may already be populated with information provided by your institution.
 
 Otherwise, you will be directed to the home page and should now be logged in.

--- a/help/user-guide/aai.md
+++ b/help/user-guide/aai.md
@@ -3,37 +3,37 @@ title: Logging into via LS Login
 ---
 
 
-{% include callout.html type="note" content="This section assumes you have an LS Login account (or your organization is connected to LS Login), 
-and LS Login authentication is enabled on the SEEK instance you are using. For more information on LS Login, please 
+{% include callout.html type="note" content="This section assumes you have an LS Login account (or your organization is connected to LS Login),
+and LS Login authentication is enabled on the SEEK instance you are using. For more information on LS Login, please
 see their [documentation](https://lifescience-ri.eu/ls-login/documentation/user-documentation/user-documentation.html){:target=\"_blank\"}." %}
 
-Already got a SEEK account? See how to [add LS Login to your account](managing-identities#add-identity) instead. 
+Already got a SEEK account? See how to [add LS Login to your account]({{ site.baseurl }}/managing-identities#add-identity) instead.
 
 If enabled on the SEEK instance you are using, you will see a tab on the login form titled "LS Login"
 
 Clicking this will switch to the LS Login tab and present the LS Login login button.
 
-![LS Login tab selected](/images/user-guide/omniauth/ls_login_button.png){:.screenshot}
+![LS Login tab selected]({{ site.baseurl }}/images/user-guide/omniauth/ls_login_button.png){:.screenshot}
 
 <a name="aai-flow"></a>
-Clicking this button will redirect your browser to LS Login, 
+Clicking this button will redirect your browser to LS Login,
 where you will be asked to choose your "Identity Provider", which will usually be your academic institution.
-If you have logged in using LS Login before, your institution may be highlighted at the top, 
+If you have logged in using LS Login before, your institution may be highlighted at the top,
 otherwise you can use the search box to find it.
 
-![LS Login identity provider selection](/images/user-guide/omniauth/ls_login_inst_choice.png){:.screenshot}
+![LS Login identity provider selection]({{ site.baseurl }}/images/user-guide/omniauth/ls_login_inst_choice.png){:.screenshot}
 
-You will then be redirected to your institution's login page, where you can login using your institution account's credentials. 
+You will then be redirected to your institution's login page, where you can login using your institution account's credentials.
 Note: this will likely look different to the screenshot below.
 
-![Institution login form](/images/user-guide/omniauth/inst_login.png){:.screenshot}
+![Institution login form]({{ site.baseurl }}/images/user-guide/omniauth/inst_login.png){:.screenshot}
 
-After logging in through your institution, you may then be presented with a personal information consent page, 
+After logging in through your institution, you may then be presented with a personal information consent page,
 which outlines what personal data will be provided by LS Login to the SEEK instance.
 
-At a minimum, the identifier must be provided, or login is not possible. Any other information is used solely to 
+At a minimum, the identifier must be provided, or login is not possible. Any other information is used solely to
 populate fields in your SEEK profile.
 
-If this is your first time logging in via LS Login, you will be directed to create a new "Profile". For guidance on how to do this, see [Registering in SEEK](registering#new-profile). Some fields such as your name and email address may already be populated with information provided by your institution.
+If this is your first time logging in via LS Login, you will be directed to create a new "Profile". For guidance on how to do this, see [Registering in SEEK]({{ site.baseurl }}/registering#new-profile). Some fields such as your name and email address may already be populated with information provided by your institution.
 
 Otherwise, you will be directed to the home page and should now be logged in.

--- a/help/user-guide/adding-admin-items.md
+++ b/help/user-guide/adding-admin-items.md
@@ -2,7 +2,7 @@
 title: Admin created items
 ---
 
-These are items that cannot be created by a general user, but can be created by a SEEK administrator, [Project Administrator](roles#project-administrator), or [Programme Administrator](roles.html#programme-administrator)
+These are items that cannot be created by a general user, but can be created by a SEEK administrator, [Project Administrator]({{ site.baseurl }}/roles#project-administrator), or [Programme Administrator]({{ site.baseurl }}/roles.html#programme-administrator)
 
 ## Creating organisms
 
@@ -14,7 +14,7 @@ An Organism can just have a title, but preferably also include the NCBI taxonomy
 
 ## Creating profiles
 
-It is possible to create profiles for people that have not registered with SEEK. This is useful if you want to describe and credit members of your Project who are not yet SEEK users. They can adopt their profile later during [Registering](registering).
+It is possible to create profiles for people that have not registered with SEEK. This is useful if you want to describe and credit members of your Project who are not yet SEEK users. They can adopt their profile later during [Registering]({{ site.baseurl }}/registering).
 
 To create a profile, choose Profile from the Create menu at the top of the page. The first and last name are required, and also the email address. The email address must be unique to SEEK.
 

--- a/help/user-guide/adding-admin-items.md
+++ b/help/user-guide/adding-admin-items.md
@@ -2,7 +2,7 @@
 title: Admin created items
 ---
 
-These are items that cannot be created by a general user, but can be created by a SEEK administrator, [Project Administrator]({{ site.baseurl }}/roles#project-administrator), or [Programme Administrator]({{ site.baseurl }}/roles.html#programme-administrator)
+These are items that cannot be created by a general user, but can be created by a SEEK administrator, [Project Administrator](roles#project-administrator), or [Programme Administrator](roles.html#programme-administrator)
 
 ## Creating organisms
 
@@ -14,7 +14,7 @@ An Organism can just have a title, but preferably also include the NCBI taxonomy
 
 ## Creating profiles
 
-It is possible to create profiles for people that have not registered with SEEK. This is useful if you want to describe and credit members of your Project who are not yet SEEK users. They can adopt their profile later during [Registering]({{ site.baseurl }}/registering).
+It is possible to create profiles for people that have not registered with SEEK. This is useful if you want to describe and credit members of your Project who are not yet SEEK users. They can adopt their profile later during [Registering](registering).
 
 To create a profile, choose Profile from the Create menu at the top of the page. The first and last name are required, and also the email address. The email address must be unique to SEEK.
 

--- a/help/user-guide/adding-assets.md
+++ b/help/user-guide/adding-assets.md
@@ -4,19 +4,19 @@ title: Adding assets (Data, Models, SOPs, Presentations, Documents) to SEEK
 
 To add a data file to SEEK, select Create from the menu bar, and select the appropriate asset from the drop down menu.
 
-![add data 1](/images/user-guide/add_data_1.png){:.screenshot}
+![add data 1]({{ site.baseurl }}/images/user-guide/add_data_1.png){:.screenshot}
 
 To add a local file you need to select Choose File
 
-![add data 2](/images/user-guide/add_data_2.png){:.screenshot}
+![add data 2]({{ site.baseurl }}/images/user-guide/add_data_2.png){:.screenshot}
 
 To add assets stored elsewhere, including other databases, select Remote URL
 
-![add data 3](/images/user-guide/add_data_3.png){:.screenshot}
+![add data 3]({{ site.baseurl }}/images/user-guide/add_data_3.png){:.screenshot}
 
 SEEK will show a preview of the link
 
-![add data 4](/images/user-guide/add_data_4.png){:.screenshot}
+![add data 4]({{ site.baseurl }}/images/user-guide/add_data_4.png){:.screenshot}
 
 
 If adding a Data file, you will now be presented with a series of steps. Please read the [Data file upload wizard](data-file-upload-wizard)

--- a/help/user-guide/browsing.md
+++ b/help/user-guide/browsing.md
@@ -5,23 +5,23 @@ title: Browsing content on SEEK
 
 Seek contains several types of content which you can access by clicking on "Browse" from any page.
 
-![Browse Content type dropdown](/images/user-guide/browsing_home.png){:.screenshot}
+![Browse Content type dropdown]({{ site.baseurl }}/images/user-guide/browsing_home.png){:.screenshot}
 
 The list of results provides filtering options, which vary depending on the type of content. For example, events can be filtered by the country where they take place.
 
-![Facet filters](/images/user-guide/browsing_filter_facets_events.png){:.screenshot}
+![Facet filters]({{ site.baseurl }}/images/user-guide/browsing_filter_facets_events.png){:.screenshot}
 
 By default, the content is listed as cards, providing title and some basic information.
 
-![Condensed view](/images/user-guide/browsing_default.png){:.screenshot}
+![Condensed view]({{ site.baseurl }}/images/user-guide/browsing_default.png){:.screenshot}
 
 
 Alternatively, a condensed view and a table view is available, showing more results at once.
-![Condensed view](/images/user-guide/browsing_condensed.png){:.screenshot}
+![Condensed view]({{ site.baseurl }}/images/user-guide/browsing_condensed.png){:.screenshot}
 
 The columns to be shown by the table view can be customised, adding/removing columns as well as choosing their order.
 
-![Table view configuration](/images/user-guide/browsing_table_config.png){:.screenshot}
+![Table view configuration]({{ site.baseurl }}/images/user-guide/browsing_table_config.png){:.screenshot}
 
 # Browsing Samples
 You can browse Samples registered in SEEK by Sample Type or by Experiment Sample Templates.
@@ -31,8 +31,8 @@ You can browse Samples registered in SEEK by Sample Type or by Experiment Sample
 * To filter by Sample Type, use the filter "Sample type" on the left side bar
 
 <div class="alert alert-info">
-Note that the ISA-JSON compliance feature must be enabled by the platform administrator for browsing by Experiment 
-Sample Template to be available. 
+Note that the ISA-JSON compliance feature must be enabled by the platform administrator for browsing by Experiment
+Sample Template to be available.
 </div>
 
 ## Browse Samples by Sample Type
@@ -70,4 +70,4 @@ Moreover, Advanced filtering allows you to further refine your query based on Ex
 * Click on Query to view your samples of interest (query’s result)
 * Click on Export table to export the result of the query as spreadsheet
 
-![Browse sample by Experiment Sample Template](/images/user-guide/isajson-compliance/browse-samples-by-isajson-template.png){:.screenshot}
+![Browse sample by Experiment Sample Template]({{ site.baseurl }}/images/user-guide/isajson-compliance/browse-samples-by-isajson-template.png){:.screenshot}

--- a/help/user-guide/bulk-change-sharing-permission.md
+++ b/help/user-guide/bulk-change-sharing-permission.md
@@ -7,13 +7,13 @@ You can change the sharing policy and permissions for your assets in batch.
 
 Find the button “Batch permission changes” by clicking the menu “My profile”.
 
-![My profile](/images/user-guide/bulk-permission-change/link-to-button.png){:.screenshot}
+![My profile]({{ site.baseurl }}/images/user-guide/bulk-permission-change/link-to-button.png){:.screenshot}
 
 By clicking "Batch permission changes",
 
-![Batch permission changes button](/images/user-guide/bulk-permission-change/button.png){:.screenshot}
+![Batch permission changes button]({{ site.baseurl }}/images/user-guide/bulk-permission-change/button.png){:.screenshot}
 
-you can see all the items you own in two lists: 
+you can see all the items you own in two lists:
 * Items in the ISA (Investigation-Study-Assay) structure, except for samples.
 * Items not in the ISA structure, including samples.
 
@@ -24,16 +24,16 @@ Note that:
 * Select items you want to change their sharing permissions by checking the checkbox;
 * If no items are selected before clicking the “next” button, the error message “Please choose at least one item!” will pop up.
 
-![my items in two lists](/images/user-guide/bulk-permission-change/two-lists.png){:.screenshot}
+![my items in two lists]({{ site.baseurl }}/images/user-guide/bulk-permission-change/two-lists.png){:.screenshot}
 
 A preview of selected assets will be given before you choose new permissions for them. you can assign new sharing policy and permission to the selected items, then click the “confirm” button. The “confirm” button will be activated only when at least one change is assigned;
-*Note*: Please note that the **Download** option is only applied to the items which are downloadable with the green arrow icon. 
+*Note*: Please note that the **Download** option is only applied to the items which are downloadable with the green arrow icon.
 
-![assign new policy and permissions](/images/user-guide/bulk-permission-change/new-policy-and-permission.png){:.screenshot}
+![assign new policy and permissions]({{ site.baseurl }}/images/user-guide/bulk-permission-change/new-policy-and-permission.png){:.screenshot}
 
 After clicking the “confirm” button, the sharing permissions of all selected items are updated and highlighted in green. The new permissions should be the same as what you assigned.
 
-![changing results](/images/user-guide/bulk-permission-change/results.png){:.screenshot}
+![changing results]({{ site.baseurl }}/images/user-guide/bulk-permission-change/results.png){:.screenshot}
 
 
 

--- a/help/user-guide/collections.md
+++ b/help/user-guide/collections.md
@@ -20,7 +20,7 @@ SEEK items that cannot be part of a collection are:
 
 Collections can be created via "Assets" section of the Create menu:
 
-![The Collection list item in the Create menu](/images/user-guide/collections/img.png){:.screenshot}
+![The Collection list item in the Create menu]({{ site.baseurl }}/images/user-guide/collections/img.png){:.screenshot}
 
 Collections share many of the same attributes as other asset types in SEEK:
 
@@ -36,29 +36,29 @@ Collections share many of the same attributes as other asset types in SEEK:
 One difference from other asset types is that Collections have "maintainers" instead of "creators".
 Maintainers have "edit" rights to the Collection - the ability to add and remove items from the Collection.
 
-![The Collection maintainers form](/images/user-guide/collections/img_1.png){:.screenshot}
+![The Collection maintainers form]({{ site.baseurl }}/images/user-guide/collections/img_1.png){:.screenshot}
 
 ## Adding to a Collection
 
-To add assets to the Collection, simply browse SEEK for the asset you wish to add. 
+To add assets to the Collection, simply browse SEEK for the asset you wish to add.
 
 If you have access to at least one Collection, a button to "Add to collection" will appear in the buttons section of the asset.
 
-![The "Add to collection" button at the top of a Data File's page](/images/user-guide/collections/img_2.png){:.screenshot}
+![The "Add to collection" button at the top of a Data File's page]({{ site.baseurl }}/images/user-guide/collections/img_2.png){:.screenshot}
 
 After clicking the button, you can also add an optional comment to explain what the asset's role in the Collection is.
 
-![The Collection comment pop-up form](/images/user-guide/collections/img_3.png){:.screenshot}
+![The Collection comment pop-up form]({{ site.baseurl }}/images/user-guide/collections/img_3.png){:.screenshot}
 
 ## Modifying a Collection
 
 To remove items from a Collection, re-order items, or modify comments on items, visit the Edit Collection page.
 
-![The "Edit Collection" button under the "Actions" dropdown menu](/images/user-guide/collections/img_4.png){:.screenshot}
+![The "Edit Collection" button under the "Actions" dropdown menu]({{ site.baseurl }}/images/user-guide/collections/img_4.png){:.screenshot}
 
 Below the title and description fields you will see all the current items in the Collection:
 
-![The "Items" section on the Collection's Edit page](/images/user-guide/collections/img_5.png){:.screenshot}
+![The "Items" section on the Collection's Edit page]({{ site.baseurl }}/images/user-guide/collections/img_5.png){:.screenshot}
 
 - To remove an item from the Collection, click the "Delete?" checkbox.
 - To re-order an item in the Collection click and drag the item using the blue numbered button on the left side above or below another item.

--- a/help/user-guide/copasi-button.md
+++ b/help/user-guide/copasi-button.md
@@ -2,33 +2,33 @@
 title: Using Copasi in SEEK
 ---
 
-You can download a public SBML format **model** to a locally installed Copasi application and start the simulation in Copasi. 
+You can download a public SBML format **model** to a locally installed Copasi application and start the simulation in Copasi.
 
 ## Prerequisites:
-* Install Copasi in your local machine. 
-  You can download the latest Copasi version [here](http://copasi.org/Download/). 
+* Install Copasi in your local machine.
+  You can download the latest Copasi version [here](http://copasi.org/Download/).
   Find more information about the COPASI scheme [here](http://copasi.org/Support/Technical_Documentation/COPASI_Scheme/).
-  
-  
-* Enable Copasi button in SEEK. 
+
+
+* Enable Copasi button in SEEK.
   By default the Copasi button is disabled. To enable the functionality described below, first go to the Admin pages (available from the user menu in the top right). Then select Site Configuration and the **Enable/disable features**. There is a checkbox to enable Copasi.
 
- 
 
-## Find a SBML format model 
+
+## Find a SBML format model
 
 If you have a SBML format model and it is publicly downloadable, the “Simulate Model in Copasi” button is visible on the top of the single model page;
 
-![Copasi button in model page](/images/user-guide/copasi/copasi-button.png){:.screenshot}
+![Copasi button in model page]({{ site.baseurl }}/images/user-guide/copasi/copasi-button.png){:.screenshot}
 
 ## Download the model and start the simulation in Copasi
 
 Click the button to download the model, the local Copasi is opened and simulation is triggered automatically;
 
-![open Copasi and download the model](/images/user-guide/copasi/open-CopasiUI.png){:.screenshot}
+![open Copasi and download the model]({{ site.baseurl }}/images/user-guide/copasi/open-CopasiUI.png){:.screenshot}
 
 Here you can see an example result.
 
-![simulate model in Copasi](/images/user-guide/copasi/result.png){:.screenshot}
+![simulate model in Copasi]({{ site.baseurl }}/images/user-guide/copasi/result.png){:.screenshot}
 
 

--- a/help/user-guide/create-a-project.md
+++ b/help/user-guide/create-a-project.md
@@ -14,13 +14,13 @@ A member of the Project will also be related to an Institution for the context o
 
 ## What is a Programme
 
-If configured to be enabled, FAIRDOM-SEEK may also have Programmes. Programmes are an umbrella that contains one or more Projects. They are a self-administered area, that describes a broad activity (usually related to a funded grant), such as a consortium, or a long-running activity that will need additional Projects. 
+If configured to be enabled, FAIRDOM-SEEK may also have Programmes. Programmes are an umbrella that contains one or more Projects. They are a self-administered area, that describes a broad activity (usually related to a funded grant), such as a consortium, or a long-running activity that will need additional Projects.
 
-Once approved, The Programme will have a [Programme Administrator](roles#programme-administrator) who is free to immediately create additional Projects without requiring additional approval. 
+Once approved, The Programme will have a [Programme Administrator](roles#programme-administrator) who is free to immediately create additional Projects without requiring additional approval.
 
 The Programme must have a title, and can optionally also have a description, funding details, website, and avatar graphic.
 
-For users that just require a single Project, and don't require a Programme, a site managed Programme can be defined (recommended) to which their Project will be associated. They will then just administer their Project without needing to worry about Programmes. Their Project can be moved to their own Programme in the future if necessary. 
+For users that just require a single Project, and don't require a Programme, a site managed Programme can be defined (recommended) to which their Project will be associated. They will then just administer their Project without needing to worry about Programmes. Their Project can be moved to their own Programme in the future if necessary.
 
 ## Creating a Project
 
@@ -30,7 +30,7 @@ You will first be prompted to create (or [Join a Project](join-a-project)) follo
 
 If enabled, first a Programme will need to be chosen or created. If configured, you will also have the option to choose a site managed Programme. By default, the site managed Programme is selected, but if unchecked there is an option to provide the title of a new one. Only the title is required at this stage, but further details can be provided later once created.
 
-![Choose Programme](/images/user-guide/create-project-select-programme.png){:.screenshot}
+![Choose Programme]({{ site.baseurl }}/images/user-guide/create-project-select-programme.png){:.screenshot}
 
 If you already administer existing Programmes, a dropdown box will be shown instead allowing you to select one of your existing Programmes. You will also have the option to create a new one.
 
@@ -38,7 +38,7 @@ If you already administer existing Programmes, a dropdown box will be shown inst
 
 You next need to define the Project. At a minimum a title is required, but you can also here provide a description and webpage. Once created you can edit and add additional details and add members.
 
-![Define Project](/images/user-guide/create-project-define-project.png){:.screenshot}
+![Define Project]({{ site.baseurl }}/images/user-guide/create-project-define-project.png){:.screenshot}
 
 ## Defining your Institution
 
@@ -49,11 +49,11 @@ Start to type the name of your institution, and existing options will be display
 
 If describing a new Institution only the title is required, but you can also provide details about its website, city and country. You will also be able to edit and add additional information afterwards.
 
-![Define Institution](/images/user-guide/create-project-define-institution.png){:.screenshot}
+![Define Institution]({{ site.baseurl }}/images/user-guide/create-project-define-institution.png){:.screenshot}
 
 ### Approval step
 
 If you are creating a Project within a Programme you administer, then there is no approval step. You will be shown a page to review the details and then create straight away.
 
-Otherwise, an appropriate administrator will be notified by email about your request. They will also be notified directly when using FAIRDOM-SEEK. The administrator will be shown a page that allows them to quickly review the details and either accept or reject the request, and in either case you will be notified by email. 
+Otherwise, an appropriate administrator will be notified by email about your request. They will also be notified directly when using FAIRDOM-SEEK. The administrator will be shown a page that allows them to quickly review the details and either accept or reject the request, and in either case you will be notified by email.
 

--- a/help/user-guide/create-sample-isajson-compliant.md
+++ b/help/user-guide/create-sample-isajson-compliant.md
@@ -29,7 +29,7 @@ Same as for material output assay sample(s), but for assays specifically designe
 ### Create Study Sources
 From Study design tab, Sources can be created in three ways.
 
-#### Via the Add row button. 
+#### Via the Add row button.
 1. Select the Add row button at the bottom of the page. One row corresponds to one Source.
 2. Make sure to fill in all the mandatory columns and then select Save.
 * Note that the light blue cells will define the name of each Source.
@@ -47,18 +47,18 @@ From Study design tab, Sources can be created in three ways.
 3. Navigate to the same Sources table from the Study design tab, click on "Choose File" button at the bottom of the page, select the saved excel file and click "Upload".
 4. Verify and confirm the upload via the pop-up window, then click "Save".
 
-![create study sources](/images/user-guide/isajson-compliance/create_samples_isastudy_source_4.png){:.screenshot}
+![create study sources]({{ site.baseurl }}/images/user-guide/isajson-compliance/create_samples_isastudy_source_4.png){:.screenshot}
 
-### Create Study Samples 
+### Create Study Samples
 In the Study design tab, Samples can be created in three ways, similar to Sources (see above). The only difference is the mandatory column "Input" in the Samples table, which must be filled with valid and existing Sources from the same Study.
 
-#### Via the Add row button. 
+#### Via the Add row button.
 Select the input Source(s) for the Sample your are creating in the "Input" column.
 
 #### Via the Paste From Clipboard button
 Ensure to select and copy all columns except for "Input", "id" and "uuid". "Input" cannot be pasted from clipboard, it must be added manually.
 
-![create study samples 5](/images/user-guide/isajson-compliance/create_samples_isastudy_samples_5.png){:.screenshot}
+![create study samples 5]({{ site.baseurl }}/images/user-guide/isajson-compliance/create_samples_isastudy_samples_5.png){:.screenshot}
 
 #### Via upload of the downloaded dynamic table
 Values for the mandatory column "Input" in the Samples table can be added in batch via spreadsheet upload.
@@ -73,11 +73,11 @@ Two input values:
 
 [{"id"=>343, "type"=>"Sample", "title"=>"yeast_wgs_02"}, {"id"=>342, "type"=>"Sample", "title"=>"yeast_wgs_01"}]
 
-![create study samples 6](/images/user-guide/isajson-compliance/create_samples_isastudy_samples_6.png){:.screenshot}
+![create study samples 6]({{ site.baseurl }}/images/user-guide/isajson-compliance/create_samples_isastudy_samples_6.png){:.screenshot}
 
 Navigate to the same Sources table from the Study design tab, click on "Choose File" button at the bottom of the page, select the saved excel file and click "Upload". Verify and confirm the upload via the pop-up window, then click "Save".
 
-### Create Assay Samples 
+### Create Assay Samples
 In the Assay design tab, Samples can be created in three ways, similar to Study Samples (see above). The only difference is the mandatory column "Input" in the Assay Samples table.
 * For first Assay, it must be filled with valid and existing Study Samples from the same Study.
 * For subsequent Assays, it must be filled with valid and existing Assay Samples from the previous Assay in the same Assay Stream.
@@ -94,7 +94,7 @@ Sources table and Samples table are interactive tables (dynamic tables) that all
 ### Samples
 In Experiment View, you can also view Study Sources, Study Samples, and Assay Samples in a searchable table by selecting "samples (n)" from the tree view on the left sidebar. Samples cannot be created or edited via this view.
 
-![dynamic table isa study source](/images/user-guide/isajson-compliance/dynamictable_isastudy_source.png){:.screenshot}
+![dynamic table isa study source]({{ site.baseurl }}/images/user-guide/isajson-compliance/dynamictable_isastudy_source.png){:.screenshot}
 
 ### Experiment overview
 Experiment overview table shows an overview of all Sources and Samples in a searchable table. Samples cannot be created or edited via this view.

--- a/help/user-guide/create-sample-type.md
+++ b/help/user-guide/create-sample-type.md
@@ -12,7 +12,7 @@ A SEEK Administrator can change the configuration such that Sample Types can onl
 
 To create a new sample type, select create from the drop down menu, and then select Sample Type from the list
 
-![menu create sample type](/images/user-guide/samples/menu-create-sample-type.png){:.screenshot}
+![menu create sample type]({{ site.baseurl }}/images/user-guide/samples/menu-create-sample-type.png){:.screenshot}
 
 A Sample Type can be made in two ways
 
@@ -26,29 +26,29 @@ A Sample Type can be made in two ways
 
 First we will show generating a Sample type through manually creating a sample type. To begin with ensure that the Form is selected.
 
-![sample type form](/images/user-guide/samples/sample-type-form.png){:.screenshot}
+![sample type form]({{ site.baseurl }}/images/user-guide/samples/sample-type-form.png){:.screenshot}
 
 Sample Type allows you to include:
- 
+
 * [Title](general-attributes#title)
 * [Description](general-attributes#description)
 * [Projects](general-attributes#projects)
 * [Tags](general-attributes#tags)
 
 
-You can define your own attributes for the Sample Type. 
+You can define your own attributes for the Sample Type.
 We would recommend using Minimum Information Checklists to assist in deciding the attributes you will need to include in your Sample Type.
 
 ## Defining Attributes
 
-All attributes must have a Name, and a selected Type. 
+All attributes must have a Name, and a selected Type.
 
 
 You can define the different types of data that the attributes should be:
 
 
 * **String**: a sequence of characters (e.g Blue)
-* **Text**: A longer alphanumerical entry (e.g. The 4th experiment in the batch, it was sampled late, so may not be as accurate). 
+* **Text**: A longer alphanumerical entry (e.g. The 4th experiment in the batch, it was sampled late, so may not be as accurate).
 * **Integer**: a whole number; not a fraction (e.g. 1, 2, 3, 4)
 * **Date**: A selected date (e.g. 2nd December 2016)
 * **Date time**: a selected date and time (e.g. 2nd December 2016 at 14:00 GMT)
@@ -57,22 +57,22 @@ You can define the different types of data that the attributes should be:
 * **Email address**: e.g. support@fair-dom.org
 * **CHEBI ID**: An identification for a specific chemical structure registered in the ChEBI database (https://www.ebi.ac.uk/chebi/) (e.g. CHEBI:17234)
 * **Boolean**: a true/false declaration, 1 or 0 can also be accepted.
-* **SEEK strain**: an internal link to a strain registered within SEEK. 
-* **SEEK sample**: an internal link to a sample registered within SEEK.  
+* **SEEK strain**: an internal link to a strain registered within SEEK.
+* **SEEK sample**: an internal link to a sample registered within SEEK.
 * **URI**: A Uniform Resource Identifier, which for example may relate to an ontology term
-* **Controlled Vocabulary**: An attribute can be a set of predefined terms you have to select from, and any other term is invalid. You can either create a new 
+* **Controlled Vocabulary**: An attribute can be a set of predefined terms you have to select from, and any other term is invalid. You can either create a new
 controlled vocabulary or reuse and existing one. In the future we will be adding ontology support the the controlled vocabularies.
 
-![sample type attributes](/images/user-guide/samples/sample-type-attributes.png){:.screenshot}
+![sample type attributes]({{ site.baseurl }}/images/user-guide/samples/sample-type-attributes.png){:.screenshot}
 
 The attribute type selected dictates the value would be accepted, and also influences how it is displayed for the Sample
 
-If you feel an attribute type is missing, it can usually be easily added so please [Contact Us](/contacting-us.html)
+If you feel an attribute type is missing, it can usually be easily added so please [Contact Us]({{ site.baseurl }}/contacting-us.html)
 
 At least one of the attributes must be required and marked as the title. This is the attribute shown in certain views or lists within SEEK.
 Other attributes can be also be marked as required if need be.
 
-![sample type attributes required](/images/user-guide/samples/sample-type-attributes-required.png){:.screenshot}
+![sample type attributes required]({{ site.baseurl }}/images/user-guide/samples/sample-type-attributes-required.png){:.screenshot}
 
 Once completed click update. Your Sample Type can now be used to generate Samples.
 
@@ -85,24 +85,24 @@ When creating the sample type, first choose the tab _Use spreadsheet template_
 
 
 On the initial Sample Template page you can include the following metadata:
- 
+
 * [Title](general-attributes.html#title)
 * [Description](general-attributes.html#description)
 * [Projects](general-attributes.html#projects)
 * [Tags](general-attributes.html#tags)
- 
+
 and then also select Choose File to select a sample template to upload:
 
-![sample type from template](/images/user-guide/samples/sample-type-from-template.png){:.screenshot}
+![sample type from template]({{ site.baseurl }}/images/user-guide/samples/sample-type-from-template.png){:.screenshot}
 
 
-Once a template is selected, and the appropriate metadata is added, select Create. 
+Once a template is selected, and the appropriate metadata is added, select Create.
 From here you will be taken to a page containing the metadata, and a list of the attribute names from the template file.
 
 Here you can select specific attribute types (the default it String). You are also free to delete, rename or reorder the attributes.
 At least one attribute must be required and set to the title, and other attributes can be marked as required if need be.
 
-![sample type attributes from template](/images/user-guide/samples/sample-type-attributes-from-template.png){:.screenshot}
+![sample type attributes from template]({{ site.baseurl }}/images/user-guide/samples/sample-type-attributes-from-template.png){:.screenshot}
 
 Once completed click update. Your Sample Type can now be used to generate Samples.
 
@@ -122,8 +122,8 @@ the link from the Sample description. However, in this case, the Sample Type won
 The Sample Type may be edited by the original creator, or somebody that can administer the related projects.
 
 If no samples have yet been created, you can freely edit the Sample Type and its attributes. Once Samples have been created for a Sample Type, it is no longer possible to modify the attributes - however other details about the Sample Type can be changed.
- 
 
-For details on how to create a Sample please go to [Creating a Sample](create-sample.html) 
+
+For details on how to create a Sample please go to [Creating a Sample](create-sample.html)
 
 

--- a/help/user-guide/create-sample.md
+++ b/help/user-guide/create-sample.md
@@ -3,36 +3,36 @@ title: Creating a Sample
 ---
 
 
-You can create a new sample directly in SEEK, or by uploading samples contained within a Sample Type Template. 
+You can create a new sample directly in SEEK, or by uploading samples contained within a Sample Type Template.
 
 
 ## Creating a Sample Directly in SEEK
 
-To create a sample directly in SEEK, select Create and then Sample in the drop down menu. 
+To create a sample directly in SEEK, select Create and then Sample in the drop down menu.
 
-![menu create sample](/images/user-guide/samples/menu-create-sample.png){:.screenshot}
+![menu create sample]({{ site.baseurl }}/images/user-guide/samples/menu-create-sample.png){:.screenshot}
 
-You will be taken to the collection of Sample Types that you can use to generate a Sample. 
-The default is the projects you are part of, but you can also search through Sample Types that are generated, 
-and publicly available, from other SEEK users. 
+You will be taken to the collection of Sample Types that you can use to generate a Sample.
+The default is the projects you are part of, but you can also search through Sample Types that are generated,
+and publicly available, from other SEEK users.
 
-![select sample type](/images/user-guide/samples/select-sample-type.png){:.screenshot}
+![select sample type]({{ site.baseurl }}/images/user-guide/samples/select-sample-type.png){:.screenshot}
 
-There may be a lot of Sample Types to choose from. To assist in your selection, 
+There may be a lot of Sample Types to choose from. To assist in your selection,
 you can filter the available samples using a single Tag, or a combination of Tags.
 
 When you have identified the Sample Type you want to use, select New Sample.
 
 The form is split into the attributes required for the sample type:
 
-![create sample attributes](/images/user-guide/samples/create-sample-attributes.png){:.screenshot}
+![create sample attributes]({{ site.baseurl }}/images/user-guide/samples/create-sample-attributes.png){:.screenshot}
 
 And then the general metadata information including
- 
+
 * [Projects](general-attributes#projects)
 * [Sharing](general-attributes#sharing)
 * [Tags](general-attributes#tags)
-* Creators 
+* Creators
 
 Once you have completed all of the information select Create.
 
@@ -41,10 +41,10 @@ Once you have completed all of the information select Create.
 
 You can bulk-create samples by populating a template and uploading as a Datafile. Once uploaded it should be recognised as having originated from a sample type template, and an option to _extract samples_ will be displayed as a button.
 
-You will be shown whilst the samples are being extracted, and then when ready a Preview button will show. This can take a while if 
+You will be shown whilst the samples are being extracted, and then when ready a Preview button will show. This can take a while if
 there are a lot of samples, and it is fine if you leave the page and revist the data file later.
 
 Once clicking the preview button you will be shown a table displaying the extracted samples, and also any rejected samples
-will be shown (i.e ones that don't match the attribute constraints). If you are happy, you can proceed to add the samples, 
-or you may want to edit the datafile and upload as a new version before extracting the samples. 
+will be shown (i.e ones that don't match the attribute constraints). If you are happy, you can proceed to add the samples,
+or you may want to edit the datafile and upload as a new version before extracting the samples.
 Once samples have been extracted you will not be able to upload a new version.

--- a/help/user-guide/data-file-upload-wizard.md
+++ b/help/user-guide/data-file-upload-wizard.md
@@ -23,7 +23,7 @@ You can also jump straight to the end or back to the start by clicking the "End"
 
 ### General information
 
-![wizard general info](/images/user-guide/data-wizard-step1.png){:.screenshot}
+![wizard general info]({{ site.baseurl }}/images/user-guide/data-wizard-step1.png){:.screenshot}
 
 You should provide the basic general metadata about the data file:
 
@@ -34,7 +34,7 @@ You should provide the basic general metadata about the data file:
 
 ### Licensing and sharing
 
-![wizard sharing](/images/user-guide/data-wizard-step2.png){:.screenshot}
+![wizard sharing]({{ site.baseurl }}/images/user-guide/data-wizard-step2.png){:.screenshot}
 
 The preferred license for the data, and sharing permissions can now be set. These will automatically be the project defaults, if they have been defined for the project.
 
@@ -43,26 +43,26 @@ The preferred license for the data, and sharing permissions can now be set. Thes
 
 ### Associated Assays
 
-![wizard assays](/images/user-guide/data-wizard-step3.png){:.screenshot}
+![wizard assays]({{ site.baseurl }}/images/user-guide/data-wizard-step3.png){:.screenshot}
 
 For this step, you can defined the Assays the Data will be linked to. This will usually be an existing Assay.
 
 * [Experimental assays and Modelling analysis](general-attributes#experimental-assays-and-modelling-analysis)
 
 If necessary, it is also possible to create a new Assay during this step:
-    
+
   * Select the New Assay tab
   * Tick the Create a New Assay checkbox
-  
+
 ### Other associated items
 
-![wizard other associations](/images/user-guide/data-wizard-step4.png){:.screenshot}
+![wizard other associations]({{ site.baseurl }}/images/user-guide/data-wizard-step4.png){:.screenshot}
 
 The final step allows you to associate the Data with other items, if necessary.
 
 * [Attributions](general-attributes#attributions)
 * [Publications](general-attributes#publications)
 * [Events](general-attributes#events)
-  
-  
+
+
 

--- a/help/user-guide/designing-experiments-isajson-compliant.md
+++ b/help/user-guide/designing-experiments-isajson-compliant.md
@@ -7,13 +7,13 @@ The [ISA metadata framework](https://isa-specs.readthedocs.io/en/latest/isamodel
 In the context of an ISA-JSON compliant experiment, we use the terms ISA Investigation, ISA Study, and ISA Assay when referring to Investigation, Study, and Assay, respectively.
 
 ## 1. Creating an ISA Investigation
-Select 
+Select
 * Create Investigation from header menu bar.
-* Alternatively, in Experiment View, select the Design Investigation button at the top right corner  
+* Alternatively, in Experiment View, select the Design Investigation button at the top right corner
 
 Fill out the provided form, check the option for "Make Investigation compliant to ISA-JSON schemas?" and then click the 'Create' button.
 
-![select isajson compliance](/images/user-guide/isajson-compliance/select_isajson_compliance.png){:.screenshot}
+![select isajson compliance]({{ site.baseurl }}/images/user-guide/isajson-compliance/select_isajson_compliance.png){:.screenshot}
 
 
 ## 2. Creating an ISA Study
@@ -39,13 +39,13 @@ The Study Sources table is a Sample Type associated with the Study and can only 
 
 * Choose one Experiment Sample Templates by clicking on "Existing Experiment Sample Templates" button.
 
-![create isastudy source 1](/images/user-guide/isajson-compliance/create_isastudy_source_1.png){:.screenshot}
+![create isastudy source 1]({{ site.baseurl }}/images/user-guide/isajson-compliance/create_isastudy_source_1.png){:.screenshot}
 
 * Filter existing Experiment Sample Templates based on:
   * the repository that will store metadata about your Study Sources (e.g. ENA, ArrayExpress or your institutional repository). Select "Project specific templates" if you want to use a template made for or by a specific Project
   * organism
 
-![create isastudy source 2](/images/user-guide/isajson-compliance/create_isastudy_source_2.png){:.screenshot}
+![create isastudy source 2]({{ site.baseurl }}/images/user-guide/isajson-compliance/create_isastudy_source_2.png){:.screenshot}
 
 * Choose a template from the resulting dropdown menu.
 * Select "Apply".
@@ -59,9 +59,9 @@ The Attributes table can be used to customise the Study Sources table. However, 
 * Fill out the mandatory and optional fields. Note that for ISA-JSON compliant Experiments, the ISA Tag is a mandatory field.
 * For ISA tag, select "source_characteristic". Note that selecting "source" would generate an error since a "source" is already selected in the starting template.
 
-![create isastudy source 3](/images/user-guide/isajson-compliance/create_isastudy_source_3.png){:.screenshot}
+![create isastudy source 3]({{ site.baseurl }}/images/user-guide/isajson-compliance/create_isastudy_source_3.png){:.screenshot}
 
-## 2.2 Link the sampling Protocol 
+## 2.2 Link the sampling Protocol
 Select Protocols already registered in the platform that describe the used method or procedure (SOP) used to collect Samples from Sources in your Study (Samples collection protocol). See how to [create an SOP](adding-assets) in SEEK.
 
 ## 2.3 Design a Samples table for Study Samples
@@ -91,7 +91,7 @@ Follow the link to know how to [create samples in ISA-JSON compliant experiments
 * Select an Assay Stream, then click on "Design Assay" button at the top right corner of the page.
 * Fill out the provided form as explained below.
 
-## 6.1 Link the sampling Protocol 
+## 6.1 Link the sampling Protocol
 Select Protocols already registered in the platform that describe the used method or procedure (SOP) applied to the Assay. See how to [create an SOP](adding-assets) in SEEK.
 
 ## 6.2 Design a Samples table for Assay
@@ -113,7 +113,7 @@ The Assay Samples table is a Sample Type associated with the Assay and can only 
     * assay - data file: if the output of the assays are digital data files
   * organism
 
-![create isaassay 2](/images/user-guide/isajson-compliance/create_isaassay_2.png){:.screenshot}
+![create isaassay 2]({{ site.baseurl }}/images/user-guide/isajson-compliance/create_isaassay_2.png){:.screenshot}
 
 * Choose a template from the resulting dropdown menu.
 * Select "Apply".
@@ -125,16 +125,16 @@ The Attributes table can be used to customise the Assay Samples table. However, 
 
 * If you want to add new attributes of your choice to your Samples table, select “Add new attribute” button.
 * Fill out the mandatory and optional fields. Note that for ISA-JSON compliant Experiments, the ISA Tag is a mandatory field.
-* For ISA tag, select 
+* For ISA tag, select
   * in case of ISA Level "assay - material": "other_material_characteristic" or "parameter_value";
   * in case of ISA Level "assay - data file": "data_file_comment" or "parameter_value";
-  
+
   Note that selecting any other options would generate an error since other options are already selected in the starting template.
 
-![create isaassay 3](/images/user-guide/isajson-compliance/create_isaassay_3.png){:.screenshot}
+![create isaassay 3]({{ site.baseurl }}/images/user-guide/isajson-compliance/create_isaassay_3.png){:.screenshot}
 
 ## 6.3 Visualise ISA Assay
 Upon creation, the newly designed ISA Assay will appear in the tree view on the left sidebar, in Experiment View. Follow the link to know more about [Experiment View](viewing-project-in-single-page).
-    
+
 ## 7. Adding samples to ISA Assay
 Follow the link to know how to [create samples in ISA-JSON compliant experiments](create-sample-isajson-compliant), including [Assay Samples](create-sample-isajson-compliant#create-assay-samples).

--- a/help/user-guide/editing-profile.md
+++ b/help/user-guide/editing-profile.md
@@ -4,15 +4,15 @@ title: Editing your profile
 
 To edit your profile, you must be logged in. When logged in you can click your name in the top right hand corner of SEEK.
 
-![edit profile 1](/images/user-guide/edit_profile_1.png){:.screenshot}
+![edit profile 1]({{ site.baseurl }}/images/user-guide/edit_profile_1.png){:.screenshot}
 
 Select My Profile from the drop down menu
 
-![edit profile 2](/images/user-guide/edit_profile_2.png){:.screenshot}
+![edit profile 2]({{ site.baseurl }}/images/user-guide/edit_profile_2.png){:.screenshot}
 
 Navigate to the Management button in the top right hand corner, and select edit profile from the drop down menu
 
-![edit profile 3](/images/user-guide/edit_profile_3.png){:.screenshot}
+![edit profile 3]({{ site.baseurl }}/images/user-guide/edit_profile_3.png){:.screenshot}
 
 The fields you can edit are straightforward and include:
 

--- a/help/user-guide/general-attributes.md
+++ b/help/user-guide/general-attributes.md
@@ -11,15 +11,15 @@ You should make titles as descriptive as possible.
 The description allows you to further expand important details.
 Descriptions can be formatted using [markdown](https://www.markdownguide.org/basic-syntax/), either via markup or using the various options above the text input (e.g. bold, italics, hyperlinks...).
 
-![Markdown ribbon UI](/images/user-guide/description_markdown_ribbon.png){:.screenshot}
+![Markdown ribbon UI]({{ site.baseurl }}/images/user-guide/description_markdown_ribbon.png){:.screenshot}
 
 
 ## Projects
 Assets can be assigned to projects in which they were created using the drop down menu.
-![add project 1](/images/user-guide/add_project_1.png){:.screenshot}
+![add project 1]({{ site.baseurl }}/images/user-guide/add_project_1.png){:.screenshot}
 
 You can remove any selected projects using the remove button.
-![add project 2](/images/user-guide/add_project_2.png){:.screenshot}
+![add project 2]({{ site.baseurl }}/images/user-guide/add_project_2.png){:.screenshot}
 
 ## Investigation details
 
@@ -29,42 +29,42 @@ You can remove any selected projects using the remove button.
 ## Biological Problem Addressed
 [Assay specific - modelling analysis] You can select which biological problem is addressed with the modelling analysis using the drop down menu. You can also add you own using the new modelling analysis type button.
 
-![Biological problem addressed 1](/images/user-guide/biological_problem_addressed_1.png){:.screenshot}
+![Biological problem addressed 1]({{ site.baseurl }}/images/user-guide/biological_problem_addressed_1.png){:.screenshot}
 
 ## Assay Type
 [Assay specific - experimental assay]
 You can select an assay type from the drop down menu, or where appropriate create a new assay type using the new assay type button.
 
-![Assay Type 1](/images/user-guide/assay_type_1.png){:.screenshot}
+![Assay Type 1]({{ site.baseurl }}/images/user-guide/assay_type_1.png){:.screenshot}
 
 ## Technology Type
 [Assay specific - experimental assay]
 You can select a technology type from the drop down menu, or where appropriate create a new technology type using the new technology type button.
 
-![Technology Type 1](/images/user-guide/technology_type_1.png){:.screenshot}
+![Technology Type 1]({{ site.baseurl }}/images/user-guide/technology_type_1.png){:.screenshot}
 
 ## Organisms
 [Assay specific]
 You can select an organism from the drop down menu.
 
-![organism 1](/images/user-guide/organism_1.png){:.screenshot}
+![organism 1]({{ site.baseurl }}/images/user-guide/organism_1.png){:.screenshot}
 
 ## Experimentalists
 
 
 ## Sharing
 
-FAIRDOM-SEEK has fine grained sharing permissions. You can choose to set an item private (no access) or to share it with selected people, institutions, projects or programmes within SEEK, or to share it publicly. 
+FAIRDOM-SEEK has fine grained sharing permissions. You can choose to set an item private (no access) or to share it with selected people, institutions, projects or programmes within SEEK, or to share it publicly.
 
-There are different levels of sharing permissions: 
+There are different levels of sharing permissions:
 * "View" allows to see only the title and description of an item;
 * "Download" gives access to the content;
 * "Edit" allows to change details of attributes of the item;
 * "Manage" gives rights to change project assignments, sharing permissions, creators or to add a temporary sharing link. Only with manage rights an item can be deleted permanently.
 
-![sharing permissions](/images/user-guide/sharing_permissions.png){:.screenshot}
+![sharing permissions]({{ site.baseurl }}/images/user-guide/sharing_permissions.png){:.screenshot}
 
-An item's sharing permissions can be set 
+An item's sharing permissions can be set
 * by managing the asset individually
 * via the "Batch permission changes" button in your user profile.
 
@@ -82,35 +82,35 @@ Non-public items can be published
 
 "Publish your assets" button in your user profile allows you to publish Assets in batch.
 
-![batch sharing publishing](/images/user-guide/bulk-permission-change/batch_sharing_publishing.png){:.screenshot}
+![batch sharing publishing]({{ site.baseurl }}/images/user-guide/bulk-permission-change/batch_sharing_publishing.png){:.screenshot}
 
 When you attempt to publish an item in a project that has gatekeeper(s), you will be shown a notice about the gatekeeper being notified.
 
 ## Tags
 Tags are key words that are relevant in some way to the asset and its properties. They are used so relevant assets can be found more easily by other users using key-word searches. To include a tag you just type it into the box. Suggestions of tags will appear in a drop down menu as you type. You are free to use any free text for tags.
 
-![add tags 1](/images/user-guide/add_tags_1.png){:.screenshot}
+![add tags 1]({{ site.baseurl }}/images/user-guide/add_tags_1.png){:.screenshot}
 
 ## Attributions
 An attribution in SEEK allows you, where appropriate, to select the asset from which your asset was derived from (stored within SEEK). As you type in the attribution, related assets will appear in a drop down menu.
 
-![add tags 1](/images/user-guide/add_attribution_1.png){:.screenshot}
+![add tags 1]({{ site.baseurl }}/images/user-guide/add_attribution_1.png){:.screenshot}
 
 ## Creators
-Creators are others who have been involved in generating the asset, through for example planning, experimentation, or analysis. 
+Creators are others who have been involved in generating the asset, through for example planning, experimentation, or analysis.
 They may not necessarily be the same person that registered the item - the Contributor.
 
 
 You can add multiple creators, either one by one. Start to type the name and matching entries will be displayed. Hit ENTER, comma or click to add the person
 
-![add creator](/images/user-guide/add-creator.png){:.screenshot}
+![add creator]({{ site.baseurl }}/images/user-guide/add-creator.png){:.screenshot}
 
 
 You can also include non-SEEK creators.
 
 You can also add non-SEEK creators using free text.
 
-![add non-SEEK creator](/images/user-guide/add-non-seek-creator.png){:.screenshot}
+![add non-SEEK creator]({{ site.baseurl }}/images/user-guide/add-non-seek-creator.png){:.screenshot}
 
 Creators can be removed easily where necessary.
 
@@ -133,28 +133,28 @@ A File Template describes conforming DataFiles. It may be annotated with informa
 ## Publications
 If your asset is directly related to a publication you can link the two together in SEEK. You can select publications within your project form the drop-down menu. If the publication is in another project you need to check the box that says associate publications from other projects.
 
-![add publication 1](/images/user-guide/add_publication_1.png){:.screenshot}
+![add publication 1]({{ site.baseurl }}/images/user-guide/add_publication_1.png){:.screenshot}
 
 When a publication is added a preview will be shown in the bottom right hand corner of SEEK. It can be removed easily if needed.
 
-![add publication 2](/images/user-guide/add_publication_2.png){:.screenshot}
+![add publication 2]({{ site.baseurl }}/images/user-guide/add_publication_2.png){:.screenshot}
 
 ## Experimental assays and Modelling analysis
 It is best that assets are contextualised using the ISA graph (more later). This means that assets where possible should be linked to an assay or an experimental analysis. This can be done by selecting an appropriate assay or experimental analysis from the drop down menu.
 
-![add assay 1](/images/user-guide/add_assay_1.png){:.screenshot}
+![add assay 1]({{ site.baseurl }}/images/user-guide/add_assay_1.png){:.screenshot}
 
 An assay preview will appear on the right hand side of SEEK once selected. The linking can be removed from the asset easily.
 
-![add assay 2](/images/user-guide/add_assay_2.png){:.screenshot}
+![add assay 2]({{ site.baseurl }}/images/user-guide/add_assay_2.png){:.screenshot}
 
 ## Experimental assays and modelling analysis
 
 ## Events
 If the asset was generated as part of an event that is registered in SEEK, you can link to the asset to the event using the drop down menu.
 
-![add event 1](/images/user-guide/add_event_1.png){:.screenshot}
+![add event 1]({{ site.baseurl }}/images/user-guide/add_event_1.png){:.screenshot}
 
 A preview of the event will appear on the right hand side of SEEK once selected. The link can be removed from the asset easily.
 
-![add event 2](/images/user-guide/add_event_2.png){:.screenshot}
+![add event 2]({{ site.baseurl }}/images/user-guide/add_event_2.png){:.screenshot}

--- a/help/user-guide/generating-the-isa-structure.md
+++ b/help/user-guide/generating-the-isa-structure.md
@@ -7,7 +7,7 @@ The ISA (Investigation, Study, Assay) is a general purpose framework for describ
 ## Creating an investigation
 The investigation is a high level concept that links related studies. To generate an Investigation select Investigation from the create menu at the top of the SEEK.
 
-![create investigation 1](/images/user-guide/create_investigation_1.png){:.screenshot}
+![create investigation 1]({{ site.baseurl }}/images/user-guide/create_investigation_1.png){:.screenshot}
 
 An investigation is described and linked using the following fields:
 
@@ -22,7 +22,7 @@ An investigation is described and linked using the following fields:
 ## Creating a study
 A study is a particular biological hypothesis or analysis. Multiple studies can be connected to an investigation. To generate a Study select Study from the create menu at the top of the SEEK.
 
-![create study 1](/images/user-guide/create_study_1.png){:.screenshot}
+![create study 1]({{ site.baseurl }}/images/user-guide/create_study_1.png){:.screenshot}
 
 A study is described and linked using the following fields:
 
@@ -37,11 +37,11 @@ A study is described and linked using the following fields:
 ## Creating an experimental assay
 An assay is in general an experiment that converts either a material or data sample, into a new material or data sample, via a protocol. Multiple assays can be connected to a Study. Experimental assays refer specifically to laboratory assays. You can select to make an experimental assay by selecting assay from the create menu at the top of the SEEK.
 
-![create assay 1](/images/user-guide/create_assay_1.png){:.screenshot}
+![create assay 1]({{ site.baseurl }}/images/user-guide/create_assay_1.png){:.screenshot}
 
 You can then choose an assay type. Select experimental assay.
 
-![create assay 1](/images/user-guide/create_assay_2.png){:.screenshot}
+![create assay 1]({{ site.baseurl }}/images/user-guide/create_assay_2.png){:.screenshot}
 
 A experimental assay is described and linked using the following fields:
 
@@ -62,11 +62,11 @@ A experimental assay is described and linked using the following fields:
 ## Creating a modelling analysis
 An assay is in general an experiment that converts either a material or data sample, into a new material or data sample, via a protocol. Multiple assays can be connected to a Study. Modelling analysis refer specifically to simulations (in silico experiments) of models. You can select to make an modelling analysis by selecting assay from the create menu at the top of the SEEK.
 
-![create assay 1](/images/user-guide/create_assay_1.png){:.screenshot}
+![create assay 1]({{ site.baseurl }}/images/user-guide/create_assay_1.png){:.screenshot}
 
 You can then choose an assay type. Select modelling analysis.
 
-![create assay 1](/images/user-guide/create_assay_2.png){:.screenshot}
+![create assay 1]({{ site.baseurl }}/images/user-guide/create_assay_2.png){:.screenshot}
 
 A modelling assay is described and linked using the following fields:
 

--- a/help/user-guide/index.md
+++ b/help/user-guide/index.md
@@ -14,22 +14,22 @@ The names of different features and functions may vary across FAIRDOM-SEEK insta
 - [Aliases across FAIRDOM-SEEK instances](./aliases)
 
 {% include callout.html type="important" content="
-Note that FAIRDOM-SEEK instances are highly customisable. Functionality such as e.g. the ISA structure, ISA-JSON compliant 
-experiments and the different asset types need to be enabled by an instance admin. 
-Therefore, some functionality described in this general user guide might not be available on your local instance. 
+Note that FAIRDOM-SEEK instances are highly customisable. Functionality such as e.g. the ISA structure, ISA-JSON compliant
+experiments and the different asset types need to be enabled by an instance admin.
+Therefore, some functionality described in this general user guide might not be available on your local instance.
 Please contact your local instance admin for more information.
 " %}
 
-## Archived help pages 
+## Archived help pages
 
-All other pages have been [archived](/help/archived) and may not provide current information. 
+All other pages have been [archived]({{ site.baseurl }}/help/archived) and may not provide current information.
 They are organised into sections for data and model annotations, controlled vocabularies and JERM.
 
 ## Contributing
 
 There are many ways in which you can contribute to the SEEK software, these documents or our [FAIRDOM](https://fair-dom.org) project.
 
-If you are interested in contributing please visit our [Contributors guide](/tech/contributing).
+If you are interested in contributing please visit our [Contributors guide]({{ site.baseurl }}/tech/contributing).
 
 
 <!-- THE FOLLOWING IS REPLACED BY THE SIDEBAR:
@@ -87,9 +87,9 @@ Capabilities
   - [Making public](investigation-snapshots.html#making-public)
   - [Snapshotting](investigation-snapshots.html#snapshotting)
   - [Creating a Research Object](investigation-snapshots.html#creating-a-research-object)
-  - [Assigning a DOI](investigation-snapshots.html#assigning-a-doi)  
-      
-## Assets      
+  - [Assigning a DOI](investigation-snapshots.html#assigning-a-doi)
+
+## Assets
 - [Adding assets (data, models, SOPs, publications) to SEEK](adding-assets.html)
 - [Data Files](general-attributes.html#data-files)
   - [Data file wizard](data-file-upload-wizard.html)
@@ -105,7 +105,7 @@ Capabilities
   - [Comparing two versions of a Model](model-comparison.html)
 
 ## Samples
-- [Samples](samples.html) 
+- [Samples](samples.html)
   - [Create a Sample Type](create-sample-type.html)
   - [Create a Sample](create-sample.html)
   - [Legacy Biosamples](legacy-biosamples.html)

--- a/help/user-guide/investigation-snapshots.md
+++ b/help/user-guide/investigation-snapshots.md
@@ -2,7 +2,7 @@
 title: Making an Investigation, Study or Assay citable
 ---
 
-SEEK allows you to publish investigations, studies and assays, replete with the structure and assets that comprise it. You can then assign a DOI to the investigation, which provides a persistent link with which you and others can use to cite them with. 
+SEEK allows you to publish investigations, studies and assays, replete with the structure and assets that comprise it. You can then assign a DOI to the investigation, which provides a persistent link with which you and others can use to cite them with.
 
 The following describes the steps to publish an investigation, but also applies to Studies and Assays.
 
@@ -14,45 +14,45 @@ The following describes the steps to publish an investigation, but also applies 
 ## Making public
 In order to make an investigation citable it must first be public. In order to make your investigation public, navigate to your investigation, and click the administration button in the top right hand corner of SEEK. Select the publish full investigation button.
 
-![publish investigation 1](/images/user-guide/publish_investigation_1.png){:.screenshot}
+![publish investigation 1]({{ site.baseurl }}/images/user-guide/publish_investigation_1.png){:.screenshot}
 
 The investigation may have some studies, assays, and other asset files which are not yet public. You can review the items that are currently not public by selecting OK in the bottom left hand corner of SEEK. Or you can skip the step if you do not want to make anything else public.
 
-![publish investigation 2](/images/user-guide/publish_investigation_2.png){:.screenshot}
+![publish investigation 2]({{ site.baseurl }}/images/user-guide/publish_investigation_2.png){:.screenshot}
 
 You will be able to check any currently unpublished assets, and given an option to make them all, or a select few of them, public.
 
-![publish investigation 3](/images/user-guide/publish_investigation_3.png){:.screenshot}
+![publish investigation 3]({{ site.baseurl }}/images/user-guide/publish_investigation_3.png){:.screenshot}
 
 You will be informed of which assets you are planning to make public. To make them public you confirm the changes in the bottom left hand corner of SEEK.
 
-![publish investigation 4](/images/user-guide/publish_investigation_4.png){:.screenshot}
+![publish investigation 4]({{ site.baseurl }}/images/user-guide/publish_investigation_4.png){:.screenshot}
 
 ## Snapshotting
 Once the investigation (at least) is public, a snapshot can be made of the investigation. Investigations are evolving and changing structures in SEEK. A snapshot is a way of freezing a version of the investigation in its current state, so that even if aspects of the investigation change over time, the frozen version can be accessed.
 
 To generate a snapshot you need to select snapshot from the administration button in the top right hand corner of the investigation screen on SEEK.
 
-![snapshotting 1](/images/user-guide/snapshotting_1.png){:.screenshot}
+![snapshotting 1]({{ site.baseurl }}/images/user-guide/snapshotting_1.png){:.screenshot}
 
 You will be given an inventory of items that will be included and excluded in the snapshot. All non-public items are excluded. You will have to make them public if you want them to be included in the snapshot. If you are happy with the contents of the snapshot you can proceed by clicking make snapshot in the bottom right hand corner.
 
-![snapshotting 2](/images/user-guide/snapshotting_2.png){:.screenshot}
+![snapshotting 2]({{ site.baseurl }}/images/user-guide/snapshotting_2.png){:.screenshot}
 
 ## Creating a Research Object
 Now that the snapshot has been taken you can download the snapshot as a research object, by selecting the download button in the top right hand corner of SEEK.
 
-![snapshotting 1](/images/user-guide/snapshotting_1.png){:.screenshot}
+![snapshotting 1]({{ site.baseurl }}/images/user-guide/snapshotting_1.png){:.screenshot}
 
 ## Assigning a DOI
 Now that the snapshot has been taken you can assign a DOI, which is a persistent identifier, to the snapshot. This allows you to persistently link to the contents of the snapshot, irrespective of whether it is moved to a different location. This allows the snapshot to be used in publications to complement or replace traditional supplementary material. It also allows for citation of your data by other researchers. You can assign a DOI by clicking the DOI button in the top right hand corner.
 
-![snapshotting 1](/images/user-guide/snapshotting_1.png){:.screenshot}
+![snapshotting 1]({{ site.baseurl }}/images/user-guide/snapshotting_1.png){:.screenshot}
 
 Once you generate a DOI, the snapshot will have a DOI logo associated with it, so you know which snapshot it is.
 
-![DOI 1](/images/user-guide/DOI_1.png){:.screenshot}
+![DOI 1]({{ site.baseurl }}/images/user-guide/DOI_1.png){:.screenshot}
 
 You will also be able to find the DOI link in the snapshots attributes
 
-![DOI 1](/images/user-guide/DOI_2.png){:.screenshot}
+![DOI 1]({{ site.baseurl }}/images/user-guide/DOI_2.png){:.screenshot}

--- a/help/user-guide/isa-json-compliant-experiment.md
+++ b/help/user-guide/isa-json-compliant-experiment.md
@@ -12,7 +12,7 @@ When using ISA-JSON compliant experiments to organise your Project, you structur
 
 In SEEK, an Investigation becomes an ISA-JSON compliant Investigation (or ISA Investigation) when the the option for "Make Investigation compliant to ISA-JSON schemas?" is selected.
 
-![select isajson compliance](/images/user-guide/isajson-compliance/select_isajson_compliance.png){:.screenshot}
+![select isajson compliance]({{ site.baseurl }}/images/user-guide/isajson-compliance/select_isajson_compliance.png){:.screenshot}
 
 ## ISA Study
 
@@ -29,7 +29,7 @@ An ISA Study is a central unit that must contain the description (metadata) of:
 ## Assay Stream
 An Assay Stream constitutes a structured sequence of sequential assays, interconnected through the flow of samples. Within an Assay Stream, the sample output of one assay serves as the input for the subsequent one. Each Assay Stream aligns with a single Assay in the ISA metadata framework. It is typically associated with one specific technology or technique, such as Metabolomics or Sequencing.
 
-![assay stream](/images/user-guide/isajson-compliance/assaystream.png){:.screenshot}
+![assay stream]({{ site.baseurl }}/images/user-guide/isajson-compliance/assaystream.png){:.screenshot}
 
 ### ISA Assay
 
@@ -52,7 +52,7 @@ The outputs of an Assay can only be used as inputs by the next Assay in the same
 
 ## Experiment Sample Templates
 
-[Experiment Sample Templates](isajson-templates) act as blueprints to create Sample Types within ISA Studies and ISA Assays and ensure that 
+[Experiment Sample Templates](isajson-templates) act as blueprints to create Sample Types within ISA Studies and ISA Assays and ensure that
 the metadata collected conforms to community standards.
 
 Experiment Sample Templates can be [provided by the platform administrator](isajson-templates#for-system-administrator) or created by Project members based on an existing template. Templates provided by the platform administrator are platform-wide (or instance-wide) and visible to every registered user. Project-specific Experiment Sample Templates created by Project members are subject to sharing permissions.
@@ -64,7 +64,7 @@ See [Experiment Sample Templates](isajson-templates) for more information.
 
 In ISA-JSON compliant experiments, samples must be created within a Sample Type derived from an Experiment Sample Template, associated with one ISA Study or one ISA Assay.
 
-The "level" of the Experiment Sample Template applied to generate a Sample Type within an ISA Study or ISA Assay determines the type of samples that will be created. Specifically, 
+The "level" of the Experiment Sample Template applied to generate a Sample Type within an ISA Study or ISA Assay determines the type of samples that will be created. Specifically,
 * ISA Study Source Template for Study Sources
 * ISA Study Sample Template for Study Samples
 * ISA material output Assay Template for material samples
@@ -74,7 +74,7 @@ See [Working with Samples in ISA-JSON compliant Experiments](create-sample-isajs
 
 ## Designing ISA-JSON compliant Experiments
 
-See [Designing ISA-JSON compliant Experiments](designing-experiments-isajson-compliant) for a step-by-step description 
+See [Designing ISA-JSON compliant Experiments](designing-experiments-isajson-compliant) for a step-by-step description
 of how to set up ISA-JSON compliant Experiments.
 
 ## ISA-JSON export

--- a/help/user-guide/isa-overview.md
+++ b/help/user-guide/isa-overview.md
@@ -7,7 +7,7 @@ title: ISA Overview
 
 The ISA overview is a graphical representation of the current item in relationship with other items within its ISA (Investigation, Study, Assay) structure.
 
-Its purpose is to give an easy visual overview, and also can be used to navigate between items in the view. By double clicking on a node, you can navigate directly to that item. 
+Its purpose is to give an easy visual overview, and also can be used to navigate between items in the view. By double clicking on a node, you can navigate directly to that item.
 The title and description of the selected item is shown at the top; text that is long can be shown in full by hovering the mouse over the text.
 
 The overview also provides the ability to modify the layout and export an image for presentations and reports.
@@ -21,8 +21,8 @@ To help identify the ISA elements, below is a summary of the icons used.
 {::options parse_block_html="true" /}
 <div id='isa-overview-avatar-legend'>
 
-| ![Investigation](/images/user-guide/isa-overview/avatar-investigation.svg) Investigation | ![Study](/images/user-guide/isa-overview/avatar-study.svg) Study | ![Assay](/images/user-guide/isa-overview/avatar-assay.svg) Assay | ![Model analysis](/images/user-guide/isa-overview/avatar-model-analysis.svg) Modelling analysis |
-| ![Event](/images/user-guide/isa-overview/avatar-event.svg) Event | ![Model](/images/user-guide/isa-overview/avatar-model.svg) Model | ![Publication](/images/user-guide/isa-overview/avatar-publication.svg) Publication | &nbsp; |
+| ![Investigation]({{ site.baseurl }}/images/user-guide/isa-overview/avatar-investigation.svg) Investigation | ![Study]({{ site.baseurl }}/images/user-guide/isa-overview/avatar-study.svg) Study | ![Assay]({{ site.baseurl }}/images/user-guide/isa-overview/avatar-assay.svg) Assay | ![Model analysis]({{ site.baseurl }}/images/user-guide/isa-overview/avatar-model-analysis.svg) Modelling analysis |
+| ![Event]({{ site.baseurl }}/images/user-guide/isa-overview/avatar-event.svg) Event | ![Model]({{ site.baseurl }}/images/user-guide/isa-overview/avatar-model.svg) Model | ![Publication]({{ site.baseurl }}/images/user-guide/isa-overview/avatar-publication.svg) Publication | &nbsp; |
 
 </div>
 
@@ -31,15 +31,15 @@ SOPs, Data files, Documents and Presentations have icons according to their file
 
 ## Tree view
 
-![Tree view](/images/user-guide/isa-overview/tree-general.png){:.screenshot}
+![Tree view]({{ site.baseurl }}/images/user-guide/isa-overview/tree-general.png){:.screenshot}
 
-The tree view is the default view, and shows the ISA structure as folders, similar to a file browser. 
-Initially, the current item and anything below it will be shown in an expanded state, whereas other items are shown collapsed. The collapsed items can be expanded by clicking on them. 
+The tree view is the default view, and shows the ISA structure as folders, similar to a file browser.
+Initially, the current item and anything below it will be shown in an expanded state, whereas other items are shown collapsed. The collapsed items can be expanded by clicking on them.
 The items that fall under the currently shown item are also highlighted with a faint blue background.
 
 For example when viewing a Study, that Study is shown expanded, whereas the sibling studies are shown collapsed.
 
-![Tree siblings collapsed](/images/user-guide/isa-overview/tree-study-focussed.png){:.screenshot}
+![Tree siblings collapsed]({{ site.baseurl }}/images/user-guide/isa-overview/tree-study-focussed.png){:.screenshot}
 
 Where items have more than one parent, for example a Data file associated with more than one Assay, then it will be shown under each of them.
 
@@ -50,30 +50,30 @@ A full screen view of the tree can be shown by toggling on the "Fullscreen" butt
 
 ## Graph view
 
-The graph view can be shown by clicking the "Graph" button at the top right. This shows a graphical view of highlighting the item within the network. 
-By default, only its immediate neighbours are shown in full, with other nodes smaller. Immediate connections are also highlighted. This helps reduce clutter for complex graphs and get an 
+The graph view can be shown by clicking the "Graph" button at the top right. This shows a graphical view of highlighting the item within the network.
+By default, only its immediate neighbours are shown in full, with other nodes smaller. Immediate connections are also highlighted. This helps reduce clutter for complex graphs and get an
 immediate visual idea of the place of the current item in the network.
- 
-![Graph view](/images/user-guide/isa-overview/graph-general.png){:.screenshot}
+
+![Graph view]({{ site.baseurl }}/images/user-guide/isa-overview/graph-general.png){:.screenshot}
 
 The graph can be interacted with by clicking on individual nodes, which will expand along with their nearest neighbours. The title and description of the selected item will also be updated at the top.
 
 If you wish all nodes to be shown in full, then there is an "All nodes" toggle button.
 
-![Graph view](/images/user-guide/isa-overview/buttons.png){:.screenshot}
+![Graph view]({{ site.baseurl }}/images/user-guide/isa-overview/buttons.png){:.screenshot}
 
-![Graph view](/images/user-guide/isa-overview/all-nodes.png){:.screenshot}
+![Graph view]({{ site.baseurl }}/images/user-guide/isa-overview/all-nodes.png){:.screenshot}
 
 You can drag the graph around with the mouse, and zoom in and out using the controls on the top left. Individual nodes can also be dragged and repositioned.
 
 As with the Tree view, you can also toggle full screen. In full screen mode it is possible to zoom in and out using the mouse wheel.
 
-To export the graph as a PNG image, then click the button with a picture icon on the top right. This will pop up an image of the current state of graph which can be downloaded. 
-The image is at a greater resolution, and more so if exported during full screen mode. 
+To export the graph as a PNG image, then click the button with a picture icon on the top right. This will pop up an image of the current state of graph which can be downloaded.
+The image is at a greater resolution, and more so if exported during full screen mode.
 
 ## Split view
 
-![Split view](/images/user-guide/isa-overview/split-general.png){:.screenshot}
+![Split view]({{ site.baseurl }}/images/user-guide/isa-overview/split-general.png){:.screenshot}
 
-The Split view provides a combination of the Tree and Graph view, with the tree shown on the right. Clicking on one interacts with the other, so clicking on a tree node will also highlight it 
+The Split view provides a combination of the Tree and Graph view, with the tree shown on the right. Clicking on one interacts with the other, so clicking on a tree node will also highlight it
 in the graph, and clicking on the graph will select the tree node and expand it if necessary. The split view works best when displayed as full screen.

--- a/help/user-guide/isajson-templates.md
+++ b/help/user-guide/isajson-templates.md
@@ -71,5 +71,5 @@ If ISA-JSON compliance feature is enabled, an option appears in the Server admin
 
 The Experiment Sample Templates must be in .json format and comply to the expected specification. JSON definitions of Experiment Sample Templates tailored for submission towards EBI repositories can be found in this [GitHub repository](https://github.com/ELIXIR-Belgium/ISA-merger).
 
-![experiment view](/images/user-guide/isajson-compliance/serveradmin-expsampletemplate-jsonupload.png){:.screenshot}
+![experiment view]({{ site.baseurl }}/images/user-guide/isajson-compliance/serveradmin-expsampletemplate-jsonupload.png){:.screenshot}
 

--- a/help/user-guide/join-a-project.md
+++ b/help/user-guide/join-a-project.md
@@ -6,11 +6,11 @@ For details about what a Project and Programme is, please see [Creating a Projec
 
 ## Joining a Project
 
-You will be prompted to join a Project when you first register and are not yet a member of one. 
+You will be prompted to join a Project when you first register and are not yet a member of one.
 
 You can also request to join a Project from a Project page itself. To do so, first navigate to the project page. As long as the Project has an administrator, and you are not yet already a member, a "Request Membership" button should be available:
 
-![Request Membership Button](/images/user-guide/request-membership-button.png){:.screenshot}
+![Request Membership Button]({{ site.baseurl }}/images/user-guide/request-membership-button.png){:.screenshot}
 
 It is only possible to make a request to the same Project once every 12 hours.
 
@@ -18,15 +18,15 @@ It is only possible to make a request to the same Project once every 12 hours.
 
 If you enter this page after make a request to join from the Project page, the Project will already be selected:
 
-![Request Join Project](/images/user-guide/request-join-project-selected.png){:.screenshot}
+![Request Join Project]({{ site.baseurl }}/images/user-guide/request-join-project-selected.png){:.screenshot}
 
-If you have entered the page directly, such as after registration you will need to select the Project you wish to join. 
+If you have entered the page directly, such as after registration you will need to select the Project you wish to join.
 
 You do this by typing the name of the Project into the box, and suggestions will be displayed. The suggestions are from matching what is typed to the Project title or part of the description. You can select up to 3 at one time. If you can't find the project you want, you can browse the full list and filter and then request to join from the Projects page as described above.
 
-![Search to Join](/images/user-guide/search-to-join-project.png){:.screenshot}
+![Search to Join]({{ site.baseurl }}/images/user-guide/search-to-join-project.png){:.screenshot}
 
-![Search to Join](/images/user-guide/search-to-join-project-selected-3.png){:.screenshot}
+![Search to Join]({{ site.baseurl }}/images/user-guide/search-to-join-project-selected-3.png){:.screenshot}
 
 ### Defining your Institution
 
@@ -36,7 +36,7 @@ Start to type the name of your Institution, and existing options will be display
 
 If describing a new Institution only the title is required, but you can also provide details about its website, city and country. You will also be able to edit and add additional information afterwards.
 
-![Define Institution](/images/user-guide/create-project-define-institution.png){:.screenshot}
+![Define Institution]({{ site.baseurl }}/images/user-guide/create-project-define-institution.png){:.screenshot}
 
 ### Providing a comment
 

--- a/help/user-guide/login.md
+++ b/help/user-guide/login.md
@@ -5,8 +5,8 @@ title: Logging into SEEK
 
 To log in you need to click the login button in the top right hand corner of SEEK.
 
-![Login 1](/images/user-guide/login_1.png){:.screenshot}
+![Login 1]({{ site.baseurl }}/images/user-guide/login_1.png){:.screenshot}
 
 This will take you to a page where you need to enter your username, and password.
 
-![Login 2](/images/user-guide/login_2.png){:.screenshot}
+![Login 2]({{ site.baseurl }}/images/user-guide/login_2.png){:.screenshot}

--- a/help/user-guide/managing-account.md
+++ b/help/user-guide/managing-account.md
@@ -5,16 +5,16 @@ title: Managing your account
 
 To manage your account you need to navigate to your profile in the top right hand corner for SEEK
 
-![edit profile 1](/images/user-guide/edit_profile_1.png){:.screenshot}
+![edit profile 1]({{ site.baseurl }}/images/user-guide/edit_profile_1.png){:.screenshot}
 
 Select My Profile from the drop down menu
 
-![edit profile 2](/images/user-guide/edit_profile_2.png){:.screenshot}
+![edit profile 2]({{ site.baseurl }}/images/user-guide/edit_profile_2.png){:.screenshot}
 
 Navigate to the Management button in the top right hand corner, and select Manage Account from the drop down menu
 
-![manage account 1](/images/user-guide/manage_account_1.png){:.screenshot}
+![manage account 1]({{ site.baseurl }}/images/user-guide/manage_account_1.png){:.screenshot}
 
 You can edit your login details within the interface
 
-![manage account 2](/images/user-guide/manage_account_2.png){:.screenshot}
+![manage account 2]({{ site.baseurl }}/images/user-guide/manage_account_2.png){:.screenshot}

--- a/help/user-guide/managing-identities.md
+++ b/help/user-guide/managing-identities.md
@@ -3,36 +3,36 @@ title: Managing Identities
 ---
 
 
-Depending on the configuration of the SEEK instance, in addition to the usual username/password method, 
-you may be able to login through one of the following: 
+Depending on the configuration of the SEEK instance, in addition to the usual username/password method,
+you may be able to login through one of the following:
  * LDAP
  * LS Login
  * GitHub
  * A custom OIDC provider
- 
+
 Each different way you login is considered an "identity", and you can potentially have multiple identities connected
 to your SEEK account.
 
 These can be managed on the "Manage Identities" page, which is found by clicking the user menu on the top-right.
 Note: This link will not appear if there are no alternative login methods enabled on the SEEK instance.
 
-![Manage Identities link](/images/user-guide/omniauth/manage_identities.png){:.screenshot}
+![Manage Identities link]({{ site.baseurl }}/images/user-guide/omniauth/manage_identities.png){:.screenshot}
 
 <a name="add-identity"></a>
 ## Adding a new identity
 
 If you already have a SEEK account and want to login using a different method, you can add a new identity by clicking the button on the top right:
 
-![Add Identity button](/images/user-guide/omniauth/add_identity.png){:.screenshot}
+![Add Identity button]({{ site.baseurl }}/images/user-guide/omniauth/add_identity.png){:.screenshot}
 
 (The options listed will vary depending on the SEEK configuration)
 
-Clicking one of the identity options will direct you to login via that provider. 
+Clicking one of the identity options will direct you to login via that provider.
 For more detail on how to proceed with LS Login, see [here](aai#aai-flow).
 
 After successfully logging in, you should be redirected back to the "Manage Identities" page, and see the new identity listed.
 
-![New identity listed](/images/user-guide/omniauth/identity_added.png){:.screenshot}
+![New identity listed]({{ site.baseurl }}/images/user-guide/omniauth/identity_added.png){:.screenshot}
 
 ## Removing an identity
 

--- a/help/user-guide/model-comparison.md
+++ b/help/user-guide/model-comparison.md
@@ -1,25 +1,25 @@
 ---
-title: Comparing two versions of a Model 
+title: Comparing two versions of a Model
 ---
 
 
 If a model has a number of versions, you can compare between two versions to see what was changed.
 
 You can only compare versions if you are logged into SEEK.
- 
-![two versions](/images/user-guide/two_versions-zoomed.png){:.screenshot}
+
+![two versions]({{ site.baseurl }}/images/user-guide/two_versions-zoomed.png){:.screenshot}
 
 Scroll down to the Version History towards the end of the page, and click _Compare_.
 
-![compare versions](/images/user-guide/compare_versions.png){:.screenshot}
+![compare versions]({{ site.baseurl }}/images/user-guide/compare_versions.png){:.screenshot}
 
 You will then be given the option to choose the models that you want to compare:
- 
-![which versions](/images/user-guide/which_versions_to_compare.png){:.screenshot} 
 
-SEEK then returns a list, and diagram containing the differences. 
+![which versions]({{ site.baseurl }}/images/user-guide/which_versions_to_compare.png){:.screenshot}
+
+SEEK then returns a list, and diagram containing the differences.
 Deletions appear in red, additions in blue, and updates that do not affect the network are in yellow.
- 
-![version diff](/images/user-guide/version_diff.png){:.screenshot} 
 
-SEEK uses [BiVES](https://sems.uni-rostock.de/projects/bives/) to compare the different models. 
+![version diff]({{ site.baseurl }}/images/user-guide/version_diff.png){:.screenshot}
+
+SEEK uses [BiVES](https://sems.uni-rostock.de/projects/bives/) to compare the different models.

--- a/help/user-guide/nels-integration.md
+++ b/help/user-guide/nels-integration.md
@@ -12,14 +12,14 @@ Pre-requisites:
 When viewing an assay in SEEK, if you have "edit" permissions, and the assay is part of a project affiliated with NeLS, you will
 see a button to "Add data from NeLS".
 
-![add data from NeLS](/images/user-guide/add_data_from_nels.png){:.screenshot}
+![add data from NeLS]({{ site.baseurl }}/images/user-guide/add_data_from_nels.png){:.screenshot}
 
 Clicking this button will redirect you to the NeLS and ask you to authenticate. This step may be skipped if you have already
 authenticated in the recent past.
 
 After authenticating with NeLS, you will return to the SEEK interface and see the NeLS browser.
 
-![NeLS browser](/images/user-guide/nels_browser.png){:.screenshot}
+![NeLS browser]({{ site.baseurl }}/images/user-guide/nels_browser.png){:.screenshot}
 
 In the left-hand pane, you should see a directory-like list of NeLS projects. If there are no projects listed, you may need to contact NeLS administrators to request access.
 
@@ -29,7 +29,7 @@ Double clicking on a project will show the datasets belonging to that project in
 
 Clicking on a dataset will show information about the dataset in the right-hand pane, as well as a list of subtypes.
 
-![Viewing a dataset](/images/user-guide/nels_dataset.png){:.screenshot}
+![Viewing a dataset]({{ site.baseurl }}/images/user-guide/nels_dataset.png){:.screenshot}
 
 Clicking the "Register" button on a subtype will open a form where you can provide additional information about the data being registered.
 
@@ -40,7 +40,7 @@ When viewing NeLS data in SEEK, two additional buttons are present on the top ri
  - *Fetch sample metadata* - If there is a sample metadata spreadsheet registered for this subtype in NeLS, click this button to import it into SEEK as [samples](samples) (only visible if you have "edit" permissions)
  - *Open in NeLS* - View the data in NeLS, prompting for login details if required.
 
-![NeLS data-specific buttons](/images/user-guide/nels_buttons.png){:.screenshot}
+![NeLS data-specific buttons]({{ site.baseurl }}/images/user-guide/nels_buttons.png){:.screenshot}
 
 ## Importing Sample Metadata
 
@@ -49,11 +49,11 @@ Clicking the "Fetch sample metadata" button will immediately import the appropri
 If a "data" sheet was present in the sample metadata spreadsheet, the contents of that sheet will be displayed in an expandable panel as shown in the screenshot below.
 This information is presented to make it easy to locate the appropriate file in NeLS for a given sample.
 
-![NeLS sample extraction and location info](/images/user-guide/nels_location_info.png){:.screenshot}
+![NeLS sample extraction and location info]({{ site.baseurl }}/images/user-guide/nels_location_info.png){:.screenshot}
 
 To complete the sample import process, click the "Review Extract Samples" button when the background task has finished.
 
-![NeLS sample review](/images/user-guide/nels_sample_extraction.png){:.screenshot}
+![NeLS sample review]({{ site.baseurl }}/images/user-guide/nels_sample_extraction.png){:.screenshot}
 
 On this page you can review the samples that SEEK has extracted from the metadata spreadsheet.
 You can also opt to link the extracted samples to an assay in the "Link to assays" section. Only assays linked to the data file will appear here. By default, the extracted samples will only be linked to the data file.

--- a/help/user-guide/openbis.md
+++ b/help/user-guide/openbis.md
@@ -4,8 +4,8 @@ title: Using SEEK with openBIS
 
 ## Enabling openBIS in SEEK
 
-By default openBIS is disabled. To enable the functionality described below, first go to the Admin pages (available from the user menu in the top right). 
-Then select *Site Configuration* and the *Enable/disable features*. 
+By default openBIS is disabled. To enable the functionality described below, first go to the Admin pages (available from the user menu in the top right).
+Then select *Site Configuration* and the *Enable/disable features*.
 There is a checkbox to enable openBIS towards the bottom of that page.
 
 ## Connecting your project to an openBIS space
@@ -15,13 +15,13 @@ There is a checkbox to enable openBIS towards the bottom of that page.
 To connect a space from an openBIS instance, you need to select *Administer openBIS* from the project administer menu, as shown
 below
 
-![admin openbis menu](/images/user-guide/openbis/admin-openbis-menu.png){:.screenshot}
+![admin openbis menu]({{ site.baseurl }}/images/user-guide/openbis/admin-openbis-menu.png){:.screenshot}
 
-From here you will see a list of the currently registered openBIS instances and spaces, 
+From here you will see a list of the currently registered openBIS instances and spaces,
 and also an button at the top giving the option
-to connect a new openBIS. 
+to connect a new openBIS.
 
-When connecting to openBIS, you will need to provide some fields. 
+When connecting to openBIS, you will need to provide some fields.
 
   * **Main Web URL** - this is the url to the front page of the openBIS you wish to connect to. When filling out this the field, the following 2 fields will be automatically populated with the default values.
   * **Application Server Endpoint** - this is the endpoint URL SEEK needs to use to query the openBIS server. If you are not sure what this is then stick with the default derived from the main web url.
@@ -33,22 +33,22 @@ When connecting to openBIS, you will need to provide some fields.
   * **Assay like types** - codes of openBIS Sample Types that will be recognized as SEEK assays
   (be default they are populate with types used with openBIS ELN).
 
-Once the above information is provided, click *Fetch spaces*. 
-This will check the above details and check the authentication. 
+Once the above information is provided, click *Fetch spaces*.
+This will check the above details and check the authentication.
 If the check is successful, the available spaces will be listed for selection.
 
-Default sharing permissions can also be defined for the space. 
+Default sharing permissions can also be defined for the space.
 These are the permissions used when registering a openBIS entity with SEEK (as Study, Assay or DataFile).
 Once registered, it is possible to change these permissions just like for any other SEEK object
 using the Administration menu (e.g. Administration/Manage Assay if registered as Assay).
 
 ## Browsing openBIS endpoint
 
-Once openBIS has been connected to a project, it can be browsed by other members of that project. 
+Once openBIS has been connected to a project, it can be browsed by other members of that project.
 On the project page, a *Browse openBIS* button will become available.
 
 Once selected, general information about it will be shown in SEEK,
-like for example number of registered openBIS experiments as SEEK Studies. 
+like for example number of registered openBIS experiments as SEEK Studies.
 
 The shown endpoint can be changed by selecting the desired space at the top of the page.
 
@@ -62,14 +62,14 @@ There are four options available:
 ## Managing OBIS Studies
 
 The available openBIS experiments are shown as cards.
- 
+
 Each card provides the standard openBIS identification details and a simplified view
 of the metadata (content) of the experiment. There is the *Show/Register* link that
-that leads to full view of the experiment and its subsequent registration/update. 
-In case of an already registered experiment as SEEK Study there is also link to 
+that leads to full view of the experiment and its subsequent registration/update.
+In case of an already registered experiment as SEEK Study there is also link to
 the study.
 
-By default only the experiments that have a type recognized as Study are displayed 
+By default only the experiments that have a type recognized as Study are displayed
 (see the openBIS config options above). Individual study-like type can be selected
 from the list or ALL TYPES to see all the openBIS experiments.
 
@@ -83,34 +83,34 @@ It presents the full experiment description (openBIS properties and attributes v
 The screen also contains cards for all the openBIS samples(objects) and datasets
 that belongs to the experiment.
 
-These samples(objects) and datasets can be registered together with experiment 
+These samples(objects) and datasets can be registered together with experiment
 as Assays and DataFiles. There are few options that can control the registration process
-of the whole Study/Assay/DataFiles tree. 
+of the whole Study/Assay/DataFiles tree.
 
 * **Automatically register dependent datasets** - all datasets that are under the experiment
 will be registered as DataFiles and linked to the new Study via *OpenBIS FILES* Assay.
 * **Automatically recognize dependent assays** - samples(objects) which types are recognized as *Assay like types*
-(see config options above) will be registered as Assays and linked to the new study. 
+(see config options above) will be registered as Assays and linked to the new study.
 * **Register with study checkboxes** - datasets and samples can be independently
- selected for registration with the experiment using the check boxes present on their card. 
+ selected for registration with the experiment using the check boxes present on their card.
  That option can be used to register samples(objects) which are not automatically
- recognized as Assays.  
+ recognized as Assays.
 
 Of course, experiment can be registered alone if none of the above option is selected.
 
-If system config allows it, 
+If system config allows it,
 there is one more option on the screen **Periodically check for new entries**.
 If selected, during periodic synchronization with openBIS SEEK will try to discover
 new datasets and samples which belongs to the experiment. The new entities will then
 also be registered as new DataFiles or Assays under the correct Study. Obviously
-it only works if Automatic registration and recognition is selected as well. 
-It only registers samples that have types likes Assays. 
+it only works if Automatic registration and recognition is selected as well.
+It only registers samples that have types likes Assays.
 Use this option wisely, only if you are routinely create new entries under that experiment
-as checking for new elements and their registration is costly operation. It may be disabled on some 
-installations. 
+as checking for new elements and their registration is costly operation. It may be disabled on some
+installations.
 
 Once register is chosen, new Study or whole Study/Assay/DataFile tree is created.
-Its visibility is set using the default sharing permission from openBIS 
+Its visibility is set using the default sharing permission from openBIS
 endpoint configuration.
 
 The Study screen contains now all the metadata from openBIS. It can now be normally
@@ -119,15 +119,15 @@ The Study can be search using the values from their openBIS metadata content.
 
 The Study screen contains also button *Registration options* that brings the openBIS
 details screen and allows changing its registration details like for example linking
-new samples. 
+new samples.
 
 ### Batch registration of experiments
 
 On the Manage Studies screen multiple experiments can be selected for bulk registration
-using the checkboxes on their cards. 
+using the checkboxes on their cards.
 
 Pressing *Batch registration* opens new dialog on which the parent Investigation
-must be selected. 
+must be selected.
 
 There is also option *Automatically recognize dependent entities* if selected not only
 new Studies will be created by whole Study/Assay/DataFiles trees using the samples and datasets
@@ -139,7 +139,7 @@ experiments.
 
 The available openBIS samples(objects) are shown as cards.
 
-By default only the samples that have a type recognized as Assay are displayed 
+By default only the samples that have a type recognized as Assay are displayed
 (see the openBIS config options above). Individual assay-like type can be selected
 from the list or ALL TYPES to see all the openBIS objects.
 
@@ -152,23 +152,23 @@ It presents the full sample description (openBIS properties and attributes value
 The screen also contains cards for all the datasets
 that belongs to the sample.
 
-These datasets can be registered together with sample as DataFiles. 
+These datasets can be registered together with sample as DataFiles.
 There two options that can control the registration process
-of the Assay with DataFiles. 
+of the Assay with DataFiles.
 
 * **Automatically register dependent datasets** - all datasets that are linked to the sample
 will be registered as DataFiles and linked to the new Assay.
 * **Register with assay checkboxes** - datasets can be independently
- selected for registration with the sample using the check boxes present on their card. 
+ selected for registration with the sample using the check boxes present on their card.
 
 Of course, sample can be registered alone if none of the above option is selected.
 
-If system config allows it, 
-there is one more option on the screen **Periodically check for new entries**, 
+If system config allows it,
+there is one more option on the screen **Periodically check for new entries**,
 described under the above "Managing Studies" section.
 
 Once register is chosen, new Assay or Assay and linked DataFiles are created.
-Its visibility is set using the default sharing permission from openBIS 
+Its visibility is set using the default sharing permission from openBIS
 endpoint configuration.
 
 The Assay screen contains now all the metadata from openBIS. It can now be normally
@@ -186,7 +186,7 @@ Again, the dependent datasets can also be automatically registered with the Assa
 ## Managing OBIS DataSets
 
 In normal circumstances datasets should be rather registered via their samples or experiments.
-But this section allows registration of individual datasets. 
+But this section allows registration of individual datasets.
 
 Managing DataSets is similar to Study or Assays so it won't be separately described.
 The only difference is that obviously DataSets don't have dependent elements that could
@@ -194,13 +194,13 @@ be registered with them as Assay of DataFiles, so the registration options are s
 
 The DataFile screen contains now all the metadata from openBIS. It can now be normally
 edited to add SEEK description or manage its access or link to assays.
-This DataFile represents the whole openBIS DataSet including all its files. 
+This DataFile represents the whole openBIS DataSet including all its files.
 It can either be downloaded as a single zip file, or individual files can be downloaded via the files link.
 
 The DataFile can be search using the values from their openBIS metadata content.
 
 Unlike their description, the actual files are not copied from OpenBIS to SEEK, they are downloaded from
-the OpenBIS directly.  
+the OpenBIS directly.
 
 ## Understanding synchronization
 
@@ -217,28 +217,28 @@ can even detects new datafiles and links them to an assay!
 Such checking takes time and it is possible that when hundreds of
 openBIS entities are registered the two hours refresh period may not be
 enough to process them all. In that case, the actual synchronization
-period for each object may be longer but rest assure that they all will get 
+period for each object may be longer but rest assure that they all will get
 checked form time to time.
 
 The Study/Assay/DataFile screen shows the details when the metadata were
-synchronized (*Last sync.* on top of the panel) as well as error messages if such 
-synchronization failed. 
+synchronized (*Last sync.* on top of the panel) as well as error messages if such
+synchronization failed.
 There is also *Sync Content* button which allows you to immediately synchronize content
 between OpenBIS and the given SEEK object.
 
 The Mange OBIS Study/Assay/DataSets screens show cached versions of each openBIS entities.
 So it is possible that if new objects were created during last *Automated Refresh Period*
-hours they are not visible on the screens. Using the *Refresh metadata* form 
+hours they are not visible on the screens. Using the *Refresh metadata* form
 Browse openBIS endpoint screen clears the cache and the current state of OpenBIS is
 presented.
 
 If content cannot be synchronized with OpenBIS for over 2 days, such
 entitiy is marked as failed and will no longer be automatically updated.
-It can still be manually synchronized afterwards.   
+It can still be manually synchronized afterwards.
 
 In some cases, administrator may decide to disable automatic synchronization
-in the SEEK configuration. In that case SEEK will always present only a past snapshot 
-unless manual synchronization is clicked. 
+in the SEEK configuration. In that case SEEK will always present only a past snapshot
+unless manual synchronization is clicked.
 
 ## Administration options
 
@@ -253,8 +253,8 @@ for content changes in OpenBIS and synchronizes them with local metadata.
 * *openbis_check_new_arrivals* - (true/false, default true) if set SEEK will not only check for
 description changes but also it will check for the newly added datasets/samples under already
 registered studies/assay and register them automatically in SEEK under a correct parent.
-* *openbis_debug* - (true/false, default false) used during development to print out some debug 
-messages about openBIS related calls and operations. 
+* *openbis_debug* - (true/false, default false) used during development to print out some debug
+messages about openBIS related calls and operations.
 
 
 

--- a/help/user-guide/programme-creation-and-management.md
+++ b/help/user-guide/programme-creation-and-management.md
@@ -17,13 +17,13 @@ If you wish to create and manage your own Projects, you will first need to creat
 Once you have [registered](registering) and logged in, you will be able to create a Programme. You can do so from Create menu
 at the top of the screen
 
-![Programme create menu](/images/user-guide/programme-create-menu.png){:.screenshot}
+![Programme create menu]({{ site.baseurl }}/images/user-guide/programme-create-menu.png){:.screenshot}
 
 This will take you to a form to fill out to describe the Programme. The title is required and must be unique, other fields are optional but encouraged if you want your Programme to be accepted.
 Once it has been created you will also be able to change the logo picture. Click the Create button at the bottom of the form to create the Programme.
 
 
-![Programme created](/images/user-guide/programme-created.png){:.screenshot}
+![Programme created]({{ site.baseurl }}/images/user-guide/programme-created.png){:.screenshot}
 
 You will now need to wait until the Programme has been activated by an administrator. The administrators will have been sent an email, will review the Programme and either accept of reject it. If rejected you will be provided with a reason. It is possible an administrator will contact you during this review process.
 The Programme will not appear in lists or search results until it has been activated.
@@ -43,7 +43,7 @@ If you are a SEEK administrator you may receive an email notifying you that a Pr
 
 This email will contain details about the Programme, who created it and also includes a link that you can follow to Accept or Reject the Programme - you need to be logged into SEEK to do this.
 
-![Programme accept or reject](/images/user-guide/programme-reject-or-accept.png){:.screenshot}
+![Programme accept or reject]({{ site.baseurl }}/images/user-guide/programme-reject-or-accept.png){:.screenshot}
 
 If you reject the programme, you will be asked for an explanation which will be passed on to the user that created it. If rejected, the Programme won't automatically be deleted and there is still the opportunity to Accept it again later
  if your reasons for rejection are addressed. You can also come back later and delete it if necessary.
@@ -56,4 +56,4 @@ their own Programmes. This will mean the Programmes, and therefore also Projects
 The option to turn these on or off are available in the Server Admin area, under Site configuration and Enable/disable features.
 
 
-![Enable programmes flag](/images/user-guide/enable-programmes-flag.png){:.screenshot}
+![Enable programmes flag]({{ site.baseurl }}/images/user-guide/enable-programmes-flag.png){:.screenshot}

--- a/help/user-guide/project-dashboard.md
+++ b/help/user-guide/project-dashboard.md
@@ -7,19 +7,19 @@ title: Project Dashboard
 
 The Project Dashboard page contains various charts presenting metrics on activity within the project over a given time period.
 
-![dashboard button](/images/user-guide/dashboard/dashboard-period-select.png){:.screenshot}
+![dashboard button]({{ site.baseurl }}/images/user-guide/dashboard/dashboard-period-select.png){:.screenshot}
 
 ## Accessing the Dashboard
 
 The dashboard is accessible to all project members through a button on the project's page.
 
-![dashboard button](/images/user-guide/dashboard/dashboard-button.png){:.screenshot}
+![dashboard button]({{ site.baseurl }}/images/user-guide/dashboard/dashboard-button.png){:.screenshot}
 
 ## Submissions
 
 The submissions graph shows all project assets that have been created over the time period. The interval can be changed to group results by day, month or year. Asset types can be excluded from the graph by clicking their entry in the legend on the right-hand side. Double-clicking an asset type will hide all asset types *except* that one.
 
-![dashboard contributions](/images/user-guide/dashboard/dashboard-contributions.png){:.screenshot}
+![dashboard contributions]({{ site.baseurl }}/images/user-guide/dashboard/dashboard-contributions.png){:.screenshot}
 
 ## Asset Accessibility
 
@@ -31,7 +31,7 @@ The three levels of accessibility are:
  * *Project accessible* - Assets that can be accessed (and downloaded if applicable) by members of this project.
  * *Other* - Assets that are private, or have limited access.
 
-![dashboard accessibility](/images/user-guide/dashboard/dashboard-accessibility.png){:.screenshot}
+![dashboard accessibility]({{ site.baseurl }}/images/user-guide/dashboard/dashboard-accessibility.png){:.screenshot}
 
 ## Most viewed and downloaded Assets
 

--- a/help/user-guide/registering.md
+++ b/help/user-guide/registering.md
@@ -4,7 +4,7 @@ title: Registering in SEEK
 
 In order to register yourself in SEEK, you need to click the Register button in the top right hand corner of SEEK.
 
-![Registration 1](/images/user-guide/register_1.png){:.screenshot}
+![Registration 1]({{ site.baseurl }}/images/user-guide/register_1.png){:.screenshot}
 
 It will take you to a screen where you need provide
 
@@ -13,7 +13,7 @@ It will take you to a screen where you need provide
 * A password for your account
 When complete click the Register button in the bottom left hand corner.
 
-![Registration 2](/images/user-guide/register_2.png){:.screenshot}
+![Registration 2]({{ site.baseurl }}/images/user-guide/register_2.png){:.screenshot}
 
 <a name="new-profile"></a>
 You will then be taken to a screen where you will enter further information. We require the following information:
@@ -28,11 +28,11 @@ In some installations of SEEK, you may be required to enter:
 
 Information that is mandatory is indicated with a red star.
 
-![Registration 3](/images/user-guide/register_3.png){:.screenshot}
+![Registration 3]({{ site.baseurl }}/images/user-guide/register_3.png){:.screenshot}
 
 After you have registered the rest of your information, in most installations of SEEK, you will need to activate your account. You will receive an email in the email account you have provided.
 
-![Registration 4](/images/user-guide/register_4.png){:.screenshot}
+![Registration 4]({{ site.baseurl }}/images/user-guide/register_4.png){:.screenshot}
 
 Once you have activated your account and logged in, you will need to either create or join a Project before you can register content, for more information please see:
 

--- a/help/user-guide/roles.md
+++ b/help/user-guide/roles.md
@@ -3,7 +3,7 @@ title: Specialist User Roles
 ---
 
 
-SEEK has a number of specialist roles to which users can be assigned 
+SEEK has a number of specialist roles to which users can be assigned
 
 Programme specific roles:
 
@@ -17,7 +17,7 @@ Project specific roles:
 
 Here is a summary of the capabilities of each role.
 
-![Roles 1](/images/user-guide/roles_1.png){:.screenshot}
+![Roles 1]({{ site.baseurl }}/images/user-guide/roles_1.png){:.screenshot}
 
 ## Programme administrator
 
@@ -54,7 +54,7 @@ The item will not become available until the asset gatekeeper has approved it.
 
 Gatekeepers can access a list of publishing requests by clicking the menu "My profile" and then the button "Assets you are Gatekeeping".
 
-![gatekeeper gatekeeping](/images/user-guide/gatekeeper_gatekeeping.png){:.screenshot}
+![gatekeeper gatekeeping]({{ site.baseurl }}/images/user-guide/gatekeeper_gatekeeping.png){:.screenshot}
 
 Gatekeepers are granted permission to view the items in question (if they don't already have it),
 so that they can decide whether to approve or reject the request.
@@ -75,7 +75,7 @@ An item is only considered *published* if its **Public** sharing permissions are
 - **View** if the item is not downloadable (Investigations, Studies, Assays...)
 - **Download** if the item is downloadable (SOPs, Documents, Data Files...)
 
-Note that this means: 
+Note that this means:
 * *downloadable* items can be set to **View** without involving the gatekeeper
 * *permissions* can be extended to individuals or groups without involving the gatekeeper
 
@@ -90,7 +90,7 @@ This applies to both items that have been created before and after the gatekeepe
 
 You can access a list of the items you have requested to be published by clicking the menu "My profile" and then the button "Assets awaiting approval".
 
-![gatekeeper awaiting approval](/images/user-guide/gatekeeper_awaiting_approval.png){:.screenshot}
+![gatekeeper awaiting approval]({{ site.baseurl }}/images/user-guide/gatekeeper_awaiting_approval.png){:.screenshot}
 
 This allows you to monitor whether the gatekeeper has made a decision on your items or not.
 If an item was rejected, you will be able to see the gatekeeper's comments from this list.

--- a/help/user-guide/simulate-on-jws-online.md
+++ b/help/user-guide/simulate-on-jws-online.md
@@ -4,11 +4,11 @@ title: Simulating Models with JWS Online
 
 Models uploaded to SEEK in SBML format can be simulated in SEEK using [JWS Online](http://jjj.mib.ac.uk/).
 
-To run a model on JWS Online you need to click the Simulate Model on JWS button. 
+To run a model on JWS Online you need to click the Simulate Model on JWS button.
 
-![run model on jws](/images/user-guide/run_model_JWS.png){:.screenshot}
+![run model on jws]({{ site.baseurl }}/images/user-guide/run_model_JWS.png){:.screenshot}
 
-The interface in SEEK will change to the JWS run environment. In this environment you are able to run a range of analysis on the model including steady state, control analysis, flux balance analysis, and more. 
+The interface in SEEK will change to the JWS run environment. In this environment you are able to run a range of analysis on the model including steady state, control analysis, flux balance analysis, and more.
 You can find out more about the JWS interface [here](http://jws-docs.readthedocs.io/)
 
-![model in jws](/images/user-guide/model_in_JWS.png){:.screenshot}
+![model in jws]({{ site.baseurl }}/images/user-guide/model_in_JWS.png){:.screenshot}

--- a/help/user-guide/templates/master-v1.md
+++ b/help/user-guide/templates/master-v1.md
@@ -19,7 +19,7 @@ The metadata sheet is included with our Samples templates, but can also be used 
 
 Below is a description about each of the fields, which has been labelled in the following screenshot:
 
-![metadata fields](/images/user-guide/templates/master-v1-template.png){:.screenshot}
+![metadata fields]({{ site.baseurl }}/images/user-guide/templates/master-v1-template.png){:.screenshot}
 
 _**1.**_  The title for the Data file entry that will be registered with SEEK
 
@@ -28,9 +28,9 @@ _**2.**_  The description that should be registered for this Data file.
 _**3.**_  The full Project SEEK ID<sup>*</sup> that the Data file will be associated with.
 
 _**4.**_  If you wish to link to an existing Assay, this should contain the full Assay SEEK ID<sup>*</sup>.
-    
+
 &nbsp;&nbsp;&nbsp;&nbsp; **OR** alternatively, you may want to create a new Assay:
-   
+
 _**5.**_  The full Study SEEK ID<sup>*</sup> that the Assay will be associated with.
 
 _**6.**_  The title for the Assay entry that will be created in SEEK
@@ -46,9 +46,8 @@ _**10.**_ If you wish to link the Assay to an existing SOP, this should contain 
 ### * SEEK ID's
 
 The SEEK ID should be the full resolvable _persistent identifier_, including the host. This can be found for any item in SEEK, and generally matches
-the URL. This isn't always the case though, such as if a SEEK is running with different aliases. For example https://fairdomhub.org/projects/19. 
+the URL. This isn't always the case though, such as if a SEEK is running with different aliases. For example https://fairdomhub.org/projects/19.
 
 It can be found near the top of page, under the description.
 
 If the ID used doesn't match the SEEK the template is being uploaded to, a warning will be given and the item ignored.
-          

--- a/help/user-guide/uploading-new-versions.md
+++ b/help/user-guide/uploading-new-versions.md
@@ -7,22 +7,22 @@ title: Creating a new version of an asset
 
 We only recommend creating new versions for minor modifications, improvements or correcting errors. If the new version changes the
 original intention or purpose of the asset, you should you create an entirely new asset entry.
- 
+
 You can upload a new version using the _Administration_ button.
 
-![upload version](/images/user-guide/upload_new_version.png){:.screenshot}
+![upload version]({{ site.baseurl }}/images/user-guide/upload_new_version.png){:.screenshot}
 
 When uploading a new model, you can either upload the file, or you can link from a remote URL e.g. from Biomodels database.
- 
-![local file or url](/images/user-guide/local_file_or_url.png){:.screenshot} 
 
-When uploading a new model version SEEK updates the file. You should include comments describing the revision. N.B: 
+![local file or url]({{ site.baseurl }}/images/user-guide/local_file_or_url.png){:.screenshot}
+
+When uploading a new model version SEEK updates the file. You should include comments describing the revision. N.B:
 If you want to edit the metadata associated with the file you need to edit this separately.
- 
-![revision comments](/images/user-guide/revision_comments.png){:.screenshot}
+
+![revision comments]({{ site.baseurl }}/images/user-guide/revision_comments.png){:.screenshot}
 
 After uploading, you will be able to see the two versions displayed in the metadata.
 
 **Note** that, earlier versions are only visible if logged into SEEK. Anonymous users can only see the latest version.
- 
-![two versions](/images/user-guide/two_versions.png){:.screenshot}
+
+![two versions]({{ site.baseurl }}/images/user-guide/two_versions.png){:.screenshot}

--- a/help/user-guide/viewing-project-in-single-page.md
+++ b/help/user-guide/viewing-project-in-single-page.md
@@ -11,5 +11,5 @@ A Project and the associated Experiments (Investigation, Study, Assay) can be vi
 
 In Experiment View, Experiments (Investigation, Study, Assay) compliant to the ISA framework (ISA-JSON compliant: true) display their Samples and linked protocols in a tree view on the left side of the page. Each item's details are shown and accessible from the center of the page, and as more items are added, the tree will expand.
 
-![experiment view](/images/user-guide/experiment_view_01.png){:.screenshot}
+![experiment view]({{ site.baseurl }}/images/user-guide/experiment_view_01.png){:.screenshot}
 

--- a/index.md
+++ b/index.md
@@ -1,22 +1,22 @@
 ---
-sidebar: false 
+sidebar: false
 title: FAIRDOM-SEEK Documentation
 ---
-![FAIRDOM-SEEK logo](/images/banner-plain.svg)
+![FAIRDOM-SEEK logo]({{ site.baseurl }}/images/banner-plain.svg)
 
 <h2>
 <i class="fa-solid fa-flask-vial fa-1x"></i> <i class="fa-solid fa-magnifying-glass-chart fa-1x"></i>
  About FAIRDOM-SEEK
 </h2>
 
-The FAIRDOM-SEEK platform is a web-based resource for sharing heterogeneous scientific research datasets, 
+The FAIRDOM-SEEK platform is a web-based resource for sharing heterogeneous scientific research datasets,
 models or simulations, processes and research outcomes. More details about SEEK can be found on the [FAIRDOM-SEEK Website](https://seek4science.org).
 
 For an example of FAIRDOM-SEEK please visit our [Demo](https://demo.seek4science.org).
 
 ### Get FAIRDOM-SEEK
 
-To find out how to install FAIRDOM-SEEK on your own machine, or install FAIRDOM-SEEK as a Virtual Machine, please go to our [<i class="fa-solid fa-flask-vial fa-1x"></i> <i class="fa-solid fa-magnifying-glass-chart fa-1x"></i> Get FAIRDOM-SEEK page](/get-seek).
+To find out how to install FAIRDOM-SEEK on your own machine, or install FAIRDOM-SEEK as a Virtual Machine, please go to our [<i class="fa-solid fa-flask-vial fa-1x"></i> <i class="fa-solid fa-magnifying-glass-chart fa-1x"></i> Get FAIRDOM-SEEK page]({{ site.baseurl }}/get-seek).
 
 ---
 
@@ -26,16 +26,16 @@ To find out how to install FAIRDOM-SEEK on your own machine, or install FAIRDOM-
 
 ### Latest User Guide
 
-General documentation on how to use and administer FAIRDOM-SEEK can be found in our [<i class="fa-solid fa-user-group fa-1x"></i> <i class="fa-solid fa-book fa-1x"></i> User Guide](/help/user-guide/).
+General documentation on how to use and administer FAIRDOM-SEEK can be found in our [<i class="fa-solid fa-user-group fa-1x"></i> <i class="fa-solid fa-book fa-1x"></i> User Guide]({{ site.baseurl }}/help/user-guide/).
 
 ### API documentation
 
-Details on how to get started using the Application Programme Interface (API) can be found in the [API Introduction](/help/user-guide/api) .
+Details on how to get started using the Application Programme Interface (API) can be found in the [API Introduction]({{ site.baseurl }}/help/user-guide/api) .
 
 ### Archived help and guidelines
 
 We also have other information for topics related to FAIRDOM-SEEK, including Metadata, ISA, and controlled vocabularies, which can be found
-in our [archive of help and guidelines](/help/).
+in our [archive of help and guidelines]({{ site.baseurl }}/help/).
 
 ---
 
@@ -43,16 +43,16 @@ in our [archive of help and guidelines](/help/).
 <i class="fa-solid fa-wrench fa-1x"></i> <i class="fa-solid fa-book-atlas fa-1x"></i>
  Technical references</h2>
 
-For more detailed information about installation and upgrading, please see our [<i class="fa-solid fa-wrench fa-1x"></i> <i class="fa-solid fa-book-atlas fa-1x"></i> Technical and Reference documentation](/tech/).
+For more detailed information about installation and upgrading, please see our [<i class="fa-solid fa-wrench fa-1x"></i> <i class="fa-solid fa-book-atlas fa-1x"></i> Technical and Reference documentation]({{ site.baseurl }}/tech/).
 
 ---
 
 <h2>
 <i class="fa-solid fa-envelopes-bulk fa-1x"></i> <i class="fa-solid fa-truck-fast fa-1x"></i> Contacting and contributions</h2>
 
-There are [<i class="fa-solid fa-envelopes-bulk fa-1x"></i>  contact details](/contacting-us), should you wish to ask a question or make a suggestion.
+There are [<i class="fa-solid fa-envelopes-bulk fa-1x"></i>  contact details]({{ site.baseurl }}/contacting-us), should you wish to ask a question or make a suggestion.
 
-We also welcome contributions, so please visit our [<i class="fa-solid fa-truck-fast fa-1x"></i> Contributors Guide](/tech/contributing).
+We also welcome contributions, so please visit our [<i class="fa-solid fa-truck-fast fa-1x"></i> Contributors Guide]({{ site.baseurl }}/tech/contributing).
 
 ---
 
@@ -61,25 +61,25 @@ We also welcome contributions, so please visit our [<i class="fa-solid fa-truck-
 
 <div class="mt-1 row row-cols-1 row-cols-md-2 row-cols-lg-3 gy-4 navigation-tiles">
     <div class="col d-grid">
-        <a role="button" class="btn py-3 fs-4 section-title" href="/help/user-guide/api"><b>API Introduction</b></a>
+        <a role="button" class="btn py-3 fs-4 section-title" href="{{ site.baseurl }}/help/user-guide/api"><b>API Introduction</b></a>
     </div>
     <div class="col d-grid">
-        <a role="button" class="btn py-3 fs-4 section-title" href="/contacting-us"><b>Contacting us</b></a>
+        <a role="button" class="btn py-3 fs-4 section-title" href="{{ site.baseurl }}/contacting-us"><b>Contacting us</b></a>
     </div>
     <div class="col d-grid">
-        <a role="button" class="btn py-3 fs-4 section-title" href="/tech/contributing"><b>Contributing</b></a>
+        <a role="button" class="btn py-3 fs-4 section-title" href="{{ site.baseurl }}/tech/contributing"><b>Contributing</b></a>
     </div>
     <div class="col d-grid">
-        <a role="button" class="btn py-3 fs-4 section-title" href="/get-seek"><b>Get FAIRDOM-SEEK</b></a>
+        <a role="button" class="btn py-3 fs-4 section-title" href="{{ site.baseurl }}/get-seek"><b>Get FAIRDOM-SEEK</b></a>
     </div>
     <div class="col d-grid">
-        <a role="button" class="btn py-3 fs-4 section-title" href="/help/user-guide/"><b>FAIRDOM-SEEK User Guide</b></a>
+        <a role="button" class="btn py-3 fs-4 section-title" href="{{ site.baseurl }}/help/user-guide/"><b>FAIRDOM-SEEK User Guide</b></a>
     </div>
     <div class="col d-grid">
-        <a role="button" class="btn py-3 fs-4 section-title" href="/tech/roadmap"><b>Roadmap</b></a>
+        <a role="button" class="btn py-3 fs-4 section-title" href="{{ site.baseurl }}/tech/roadmap"><b>Roadmap</b></a>
     </div>
     <div class="col d-grid">
-        <a role="button" class="btn py-3 fs-4 section-title" href="/tech/useful-links"><b>Useful Links</b></a>
+        <a role="button" class="btn py-3 fs-4 section-title" href="{{ site.baseurl }}/tech/useful-links"><b>Useful Links</b></a>
     </div>
 </div>
 

--- a/tech/contributing-to-seek.md
+++ b/tech/contributing-to-seek.md
@@ -7,8 +7,8 @@ We welcome all sorts of contributions to SEEK,
 
 * **Non-developer contributions.** These are contributions that can be made by anyone
   using SEEK.
-  * *Vote and comment other feature requests:* [Contact us](/contacting-us) please use the [SEEK issue tracker](https://fair-dom.org/issues). 
-  * *Documentation:* Are you reading the documentation and feel something could/should be better explained? Please read [Contributing to these Pages](/tech/contributing-to-pages)
+  * *Vote and comment other feature requests:* [Contact us](/contacting-us) please use the [SEEK issue tracker](https://fair-dom.org/issues).
+  * *Documentation:* Are you reading the documentation and feel something could/should be better explained? Please read [Contributing to these Pages]({{ site.baseurl }}/tech/contributing-to-pages)
   * *Reporting errors:* We are also thankful if you spot errors or broken links.
 * **Developer contributions** These are contributions that can be made by other software
   developers.

--- a/tech/contributing.md
+++ b/tech/contributing.md
@@ -14,10 +14,10 @@ However, if there other ways you feel you can contribute, such as running a work
 
 ## Contributing to SEEK
 
-Please read [contributing to SEEK](/tech/contributing-to-seek) or [reporting a bug or feature request](/tech/reporting-bugs-and-features).
+Please read [contributing to SEEK]({{ site.baseurl }}/tech/contributing-to-seek) or [reporting a bug or feature request]({{ site.baseurl }}/tech/reporting-bugs-and-features).
 
 
 ## Contributing to these pages
 
 You can also contribute to these pages.
-Please read [contributing to these pages](/tech/contributing-to-pages) and the [style guide](/tech/style-guide).
+Please read [contributing to these pages]({{ site.baseurl }}/tech/contributing-to-pages) and the [style guide]({{ site.baseurl }}/tech/style-guide).

--- a/tech/earlier-upgrades.md
+++ b/tech/earlier-upgrades.md
@@ -8,7 +8,7 @@ redirect_from: "/earlier-upgrades.html"
 **Also if upgrading from a Mercurial based SEEK to our Git one, please contact
 us. Mercurial versions of SEEK are only available up to v0.21.**
 
-You can find details on how to contact us at the [Contact Page](/contacting-us)
+You can find details on how to contact us at the [Contact Page]({{ site.baseurl }}/contacting-us)
 
 When upgrading between versions greater than v0.11.x you need to upgrade to
 each released minor version in order incrementally (i.e. 0.13.x -> 0.14.x ->
@@ -28,7 +28,7 @@ followed by the version - e.g. v0.11.1, v0.13.2, v0.17.1
 
 ### Stopping services before upgrading
 
-    bundle exec rake seek:workers:stop 
+    bundle exec rake seek:workers:stop
 
 ### Getting the upgrade
 
@@ -136,7 +136,7 @@ you may remove 3.7 unless it is used for other applications. If unsure there is 
 
 ### Stopping services before upgrading
 
-    bundle exec rake seek:workers:stop 
+    bundle exec rake seek:workers:stop
 
 ### Getting the upgrade
 
@@ -207,7 +207,7 @@ SEEK requires some cron jobs for periodic background jobs to run. To update thes
 ### Restarting background job services
 
     bundle exec rake seek:workers:start
- 
+
 ---
 
 ## Steps to upgrade from 1.12.x to 1.13.x
@@ -235,7 +235,7 @@ and now install the packages:
 
 ### Stopping services before upgrading
 
-    bundle exec rake seek:workers:stop 
+    bundle exec rake seek:workers:stop
 
 ### Updating from GitHub
 
@@ -363,7 +363,7 @@ content.
     gem install bundler
     bundle install --deployment --without development test
     bundle exec rake seek:upgrade
-    bundle exec rake assets:precompile # this task will take a while       
+    bundle exec rake assets:precompile # this task will take a while
 
 ### Update Cron Services
 
@@ -379,7 +379,7 @@ It is relatively straightforward and there are instructions on how to do this in
 
 ### Restarting background job services
 
-    bundle exec rake seek:workers:start    
+    bundle exec rake seek:workers:start
 
 ## Stopping soffice
 
@@ -447,7 +447,7 @@ content.
     gem install bundler
     bundle install --deployment --without development test
     bundle exec rake seek:upgrade
-    bundle exec rake assets:precompile # this task will take a while       
+    bundle exec rake assets:precompile # this task will take a while
 
 ### Setup Cron Services
 
@@ -458,9 +458,9 @@ This version includes an update to ActiveJob and requires some cron jobs for per
 ### Restarting services
 
     bundle exec rake sunspot:solr:start
-    bundle exec rake seek:workers:start                
-    
-    bundle exec rake tmp:clear  
+    bundle exec rake seek:workers:start
+
+    bundle exec rake tmp:clear
 
 ---
 
@@ -474,7 +474,7 @@ If you are not prompted you can install with the command:
     rvm install ruby-2.4.10
 
 ### Set RAILS_ENV
-              
+
 
 **If upgrading a production instance of SEEK, remember to set the RAILS_ENV first**
 
@@ -521,15 +521,15 @@ content.
     gem install bundler
     bundle install --deployment
     bundle exec rake seek:upgrade
-    bundle exec rake assets:precompile # this task will take a while       
-       
+    bundle exec rake assets:precompile # this task will take a while
+
 
 ### Restarting services
 
     bundle exec rake sunspot:solr:start
-    bundle exec rake seek:workers:start                
-    
-    bundle exec rake tmp:clear         
+    bundle exec rake seek:workers:start
+
+    bundle exec rake tmp:clear
 
 ---
 
@@ -543,7 +543,7 @@ If you are not prompted you can install with the command:
     rvm install ruby-2.4.9
 
 ### Set RAILS_ENV
-              
+
 
 **If upgrading a production instance of SEEK, remember to set the RAILS_ENV first**
 
@@ -591,17 +591,17 @@ content.
     gem install bundler
     bundle install --deployment
     bundle exec rake seek:upgrade
-    bundle exec rake assets:precompile # this task will take a while       
-       
+    bundle exec rake assets:precompile # this task will take a while
+
 
 ### Restarting services
 
     bundle exec rake sunspot:solr:start
-    bundle exec rake seek:workers:start                
-    
+    bundle exec rake seek:workers:start
+
     bundle exec rake tmp:clear
 
----    
+---
 
 ## Steps to upgrade from 1.7.x to 1.8.x
 
@@ -613,7 +613,7 @@ If you are not prompted you can install with the command:
     rvm install ruby-2.4.5
 
 ### Set RAILS_ENV
-              
+
 
 **If upgrading a production instance of SEEK, remember to set the RAILS_ENV first**
 
@@ -661,17 +661,17 @@ content.
     gem install bundler
     bundle install --deployment
     bundle exec rake seek:upgrade
-    bundle exec rake assets:precompile # this task will take a while       
-       
+    bundle exec rake assets:precompile # this task will take a while
+
 
 ### Restarting services
 
     bundle exec rake sunspot:solr:start
-    bundle exec rake seek:workers:start                
-    
+    bundle exec rake seek:workers:start
+
     bundle exec rake tmp:clear
-    
----    
+
+---
 
 ## Steps to upgrade from 1.6.x to 1.7.x
 
@@ -684,7 +684,7 @@ If you are not prompted you can install with the command:
 
 
 ### Set RAILS_ENV
-              
+
 
 **If upgrading a production instance of SEEK, remember to set the RAILS_ENV first**
 
@@ -732,18 +732,18 @@ content.
     gem install bundler
     bundle install --deployment
     bundle exec rake seek:upgrade
-    bundle exec rake assets:precompile # this task will take a while       
-       
+    bundle exec rake assets:precompile # this task will take a while
+
 
 ### Restarting services
 
     bundle exec rake sunspot:solr:start
-    bundle exec rake seek:workers:start                
+    bundle exec rake seek:workers:start
 
     touch tmp/restart.txt
     bundle exec rake tmp:clear
-    
----    
+
+---
 
 ## Steps to upgrade from 1.5.x to 1.6.x
 
@@ -752,24 +752,24 @@ content.
 This version requires at least **Java 8**. Please make sure this is installed by trying:
 
     java --version
-    
+
 which should report java version 1.8.0 or greater. If not, install with:
 
     sudo apt install openjdk-8-jdk
     java --version
 
 if this still doesn't report the correct version you may need to do:
-   
+
     sudo update-alternatives --config java
-    
+
 .. and select the _java-8_ version
 
-You can also use the Oracle version of Java 8. This can be easily installed with Apt, through the 
+You can also use the Oracle version of Java 8. This can be easily installed with Apt, through the
 [Oracle PPA](https://www.digitalocean.com/community/tutorials/how-to-install-java-with-apt-get-on-ubuntu-16-04)
 
 
 ### Set RAILS_ENV
-              
+
 
 **If upgrading a production instance of SEEK, remember to set the RAILS_ENV first**
 
@@ -817,15 +817,15 @@ content.
     gem install bundler
     bundle install --deployment
     bundle exec rake seek:upgrade
-    bundle exec rake assets:precompile # this task will take a while       
-       
+    bundle exec rake assets:precompile # this task will take a while
+
 
 ### Restarting services
 
     bundle exec rake sunspot:solr:start
     bundle exec rake seek:workers:start
-    
----    
+
+---
 
 
 ## Steps to upgrade from 1.4.x to 1.5.x
@@ -872,7 +872,7 @@ If you have a modified _config/sunspot.yml_ you will also need to copy that acro
 ### Update RVM and Ruby
 
     rvm get stable
-    rvm install $(cat .ruby-version) 
+    rvm install $(cat .ruby-version)
 
 ### Doing the upgrade
 
@@ -885,18 +885,18 @@ content.
     bundle install --deployment
     bundle exec rake seek:upgrade
     bundle exec rake assets:precompile # this task will take a while
-    
+
 **Note**: During the upgrade, and items that previously were shared with _All registered users_ have had their permissions updated,
 and this permission has been transferred to its associated projects. An audit CSV file is created, tmp/all-users-policy-update-audit-<timestamp>.csv .
-This file contains a list of all the items affected, along with the contributor and project ids.    
-       
+This file contains a list of all the items affected, along with the contributor and project ids.
+
 
 ### Restarting services
 
     bundle exec rake sunspot:solr:start
-    bundle exec rake seek:workers:start  
-    
----    
+    bundle exec rake seek:workers:start
+
+---
 
 ## Steps to upgrade from 1.3.x to 1.4.x
 
@@ -944,7 +944,7 @@ If you have a modified _config/sunspot.yml_ you will also need to copy that acro
 ### Update RVM and Ruby
 
     rvm get stable
-    rvm install $(cat .ruby-version) 
+    rvm install $(cat .ruby-version)
 
 ### Doing the upgrade
 
@@ -957,35 +957,35 @@ content.
     bundle install --deployment
     bundle exec rake seek:upgrade
     bundle exec rake assets:precompile # this task will take a while
-    
+
 ### Updating the Sunspot configuration
-    
+
 If you moved away from the default Sunspot/SOLR config, by making your own copy of _config/sunspot.yml_, this will need updating.
 
 If you don't have a _config/sunspot.yml_ you don't need to do anything.
-   
-Update your _sunspot.yml_ based on the new format in _[config/sunspot.default.yml](https://raw.githubusercontent.com/seek4science/seek/v1.4.1/config/sunspot.default.yml)_   
+
+Update your _sunspot.yml_ based on the new format in _[config/sunspot.default.yml](https://raw.githubusercontent.com/seek4science/seek/v1.4.1/config/sunspot.default.yml)_
 
 ### Restarting services
 
     bundle exec rake sunspot:solr:start
-    bundle exec rake seek:workers:start            
+    bundle exec rake seek:workers:start
 
 If you are running a production SEEK behing Apache, then move onto the next part. Otherwise, or you want to do a quick test,
- you can simply start SEEK again with:  
-  
-    bundle exec rails s    
-            
-    
+ you can simply start SEEK again with:
+
+    bundle exec rails s
+
+
 ### Upgrading Passenger Phusion
-    
+
 If you are running SEEK with Passenger, it is likely you will need to upgrade Passenger and your Apache or Ngninx configuration.
- 
-Please read [Serving SEEK through Apache](/tech/install-production#serving-seek-through-apache) for a reminder
+
+Please read [Serving SEEK through Apache]({{ site.baseurl }}/tech/install-production#serving-seek-through-apache) for a reminder
 on how to install the new version, and update your virtual host configuration accordingly.
 
 ### Note on Search results
-    
+
 Initially you won't get any search results, due to the upgrade of Sunspot/SOLR. The upgrade steps will have triggered
 some jobs to rebuild the search index. How long this takes depends upon the number of items in the database and the speed of your
 machine. You can track the progress by going to the Admin page of _SEEK_, and looking at _Job Queue_ under _Statistics_.
@@ -1408,8 +1408,8 @@ and other necessary changes:
     bundle exec rake tmp:clear
 
 ---
-    
-    
+
+
 
 # Upgrades to 0.21.x and earlier
 
@@ -1516,8 +1516,8 @@ You may also need to enable a couple of Apache modules, so run:
 You will then need to restart Apache
 
     sudo service apache2 restart
-    
----    
+
+---
 
 ## Steps to upgrade from 0.18.x to 0.19.x
 
@@ -1538,8 +1538,8 @@ Upgrading follows the standard steps:
     touch tmp/restart.txt
     bundle exec rake tmp:assets:clear RAILS_ENV=production
     bundle exec rake tmp:clear RAILS_ENV=production
-    
----    
+
+---
 
 ## Steps to upgrade from 0.17.x to 0.18.x
 

--- a/tech/extended-metadata/a-complete-example.md
+++ b/tech/extended-metadata/a-complete-example.md
@@ -4,17 +4,17 @@ title: A Complete Example to Create Extended Metadata Types by Uploading a JSON 
 
 Here is a step-by-step example of how to create a new extended metadata type using all the attribute types mentioned in our guide: [Create Extended Metatypes by Uploading a JSON File](create-extended-metadata-type-with-json-file).
 
-## Step 1: Define Controlled Vocabularies 
+## Step 1: Define Controlled Vocabularies
 
 Currently, controlled vocabularies can only be created through the user interface by anyone with permission to create resources in SEEK.
 
 You can also use the following direct link  ```HTTP://{HOST_NAME}/sample_controlled_vocabs/new``` to create controlled vocabularies or the button on the [Controlled Vocabulary](manage-extended-metadata-type/#3-controlled-vocabularies-tab) tab.
 
 Assuming the controlled vocabularies have been created here:
-![extended-metadata-fields](/images/user-guide/extended-metadata/cvs-tab.png)
+![extended-metadata-fields]({{ site.baseurl }}/images/user-guide/extended-metadata/cvs-tab.png)
 
-You can view the detailed controlled vocabularies by clicking the corresponding its ID. 
-![extended-metadata-fields](/images/user-guide/extended-metadata/role_name_identifier_scheme_cv.png)
+You can view the detailed controlled vocabularies by clicking the corresponding its ID.
+![extended-metadata-fields]({{ site.baseurl }}/images/user-guide/extended-metadata/role_name_identifier_scheme_cv.png)
 
 ## Step 2: Define Nested Extended Metadata Types
 
@@ -183,9 +183,9 @@ Step 2.2. Define a new metadata type called `role_emt`, which will have one attr
 }
 ```
 
-## Step 4: Use Extended Metadata Type 
+## Step 4: Use Extended Metadata Type
 
 As the result, you can choose to load this extended metadata type on the study creation page.
-![](/images/user-guide/extended-metadata/emt-ui.png)
+![]({{ site.baseurl }}/images/user-guide/extended-metadata/emt-ui.png)
 
 

--- a/tech/extended-metadata/extended-metadata-type.md
+++ b/tech/extended-metadata/extended-metadata-type.md
@@ -5,7 +5,7 @@ redirect_from: '/tech/extended-metadata'
 
 ## Introduction
 
-Extended Metadata is a feature added to SEEK as part of [version 1.11](/tech/releases/#version-1110), originally to support
+Extended Metadata is a feature added to SEEK as part of [version 1.11]({{ site.baseurl }}/tech/releases/#version-1110), originally to support
 MIAPPE but designed for future use.
 It provides the ability to define additional metadata attributes for a particular type, to support a particular standard (i.e MIAPPE).
 
@@ -15,12 +15,12 @@ You may sometimes hear or read it referred to as Custom Metadata, and they are t
 It is not a feature a user would directly see, other than revealed through extensions that are made available:
 
 
-![extended-metadata-select](/images/user-guide/extended-metadata/extended-metadata-select.png)
+![extended-metadata-select]({{ site.baseurl }}/images/user-guide/extended-metadata/extended-metadata-select.png)
 
 
 ... will reveal new fields below:
 
-![extended-metadata-fields](/images/user-guide/extended-metadata/extended-metadata-fields.png)
+![extended-metadata-fields]({{ site.baseurl }}/images/user-guide/extended-metadata/extended-metadata-fields.png)
 
 The attributes can be associated with a particular attribute type, and marked as optional or mandatory, and will be validated against. This is very similar to Samples.
 
@@ -42,14 +42,14 @@ You can define the supported resource type as shown below:
 ExtendedMetadataType.new(title: 'person', supported_type: 'YOUR_TYPE_NAME')
 ```
 
-Extended Metadata Type is conceptually similar to a Sample Type, as it inherits the same attribute structure. However, while Sample Types are used to create standalone Samples, Extended Metadata Types are used to augment or extend the metadata of other types (e.g., Investigations, Studies, or Assays). 
+Extended Metadata Type is conceptually similar to a Sample Type, as it inherits the same attribute structure. However, while Sample Types are used to create standalone Samples, Extended Metadata Types are used to augment or extend the metadata of other types (e.g., Investigations, Studies, or Assays).
 Instead of existing independently, extended metadata is embedded within another object, enriching its descriptive details.
 
-This is explained in the following high level representation. 
+This is explained in the following high level representation.
 
-![](/images/user-guide/extended-metadata/high-level-arch.png)
+![]({{ site.baseurl }}/images/user-guide/extended-metadata/high-level-arch.png)
 
-In this diagram: 
+In this diagram:
 
 **Sample Type:**
 
@@ -80,7 +80,7 @@ In this diagram:
 As a SEEK instance administrator, you have the ability to create, manage (enable, disable), and delete extended metadata types. This guide will walk you through how to perform these actions efficiently by navigating to the "Manage Extended Metadata Types" section in the Admin area.
 
 
-![emt-top-level-tab](/images/user-guide/extended-metadata/emt-management.png)
+![emt-top-level-tab]({{ site.baseurl }}/images/user-guide/extended-metadata/emt-management.png)
 
 
 * **[Manage Extended Metadata Types](manage-extended-metadata-type)**

--- a/tech/extended-metadata/manage-extended-metadata-type.md
+++ b/tech/extended-metadata/manage-extended-metadata-type.md
@@ -10,7 +10,7 @@ On the "Manage Extended Metadata Types" page, you will see a list of existing ex
 
 This tab displays all top-level extended metadata types, which are associated with specific resource types in SEEK, including <a id="top-level-resource-type">`Investigation`, `Study`, `Assay`, `Collection`, `DataFile`, `Document`, `Event`, `Model`, `Presentation`, `Sop`, and `Project`</a>.
 
-![](/images/user-guide/extended-metadata/emt-top-level-tab.png)
+![]({{ site.baseurl }}/images/user-guide/extended-metadata/emt-top-level-tab.png)
 
 
 The table on this tab contains the following columns:
@@ -21,7 +21,7 @@ The table on this tab contains the following columns:
 * **Title:**  The name of the extended metadata type, which appears in the dropdown list when creating a new resource.
 
 
-* **Supported Type:**  The SEEK [top level resource types](#1-top-level-tab-) associated with this extended metadata type. 
+* **Supported Type:**  The SEEK [top level resource types](#1-top-level-tab-) associated with this extended metadata type.
 
 
 * **Number of Times Used**:  The number of times metadata has been created based on this extended metadata type.
@@ -37,7 +37,7 @@ The table on this tab contains the following columns:
 
 ## 2. Nested Level Tab
 
-![](/images/user-guide/extended-metadata/emt-nested-level-tab.png)
+![]({{ site.baseurl }}/images/user-guide/extended-metadata/emt-nested-level-tab.png)
 
 
 This tab lists all extended metadata types with the supported type "ExtendedMetadata." Nested-level metadata types are primarily used to define attributes like `Linked Extended Metadata` or `Linked Extended Metadata (Multiple)`, allowing for deeper, more flexible relationships between metadata.
@@ -50,7 +50,7 @@ Extended metadata types in this tab cannot be deleted if they are linked to othe
 
 This tab lists all the controlled vocabularies (CV) available in SEEK, which can be used when defining sample types or extended metadata types. Administrators can create new controlled vocabularies by clicking the "Create Controlled Vocabulary" button.
 
-![extended-metadata-fields](/images/user-guide/extended-metadata/cvs-tab.png)
+![extended-metadata-fields]({{ site.baseurl }}/images/user-guide/extended-metadata/cvs-tab.png)
 
 
 The Internal ID of a controlled vocabulary is important when defining attributes such as `Controlled Vocabulary` or `Controlled Vocabulary List`.
@@ -60,7 +60,7 @@ The Internal ID of a controlled vocabulary is important when defining attributes
 This tab provides a list of all supported extended metadata attribute types. The Title of each attribute type is crucial, as it is used when defining a custom JSON file for creating new extended metadata types.
 
 
-![](/images/user-guide/extended-metadata/emas-tab.png)
+![]({{ site.baseurl }}/images/user-guide/extended-metadata/emas-tab.png)
 
 
 Back to [Extended Metadata Technical Overview](extended-metadata-type)

--- a/tech/index.md
+++ b/tech/index.md
@@ -9,13 +9,13 @@ Please see the menu to the left for technical and reference documentation, or us
 
 ## Featured help: Installing FAIRDOM-SEEK
 
-- [Installing SEEK](/tech/install)
+- [Installing SEEK]({{ site.baseurl }}/tech/install)
 
 
 ## Contributing
 
 There are many ways in which you can contribute to the SEEK software, these documents or our [FAIRDOM](https://fair-dom.org) project.
 
-If you are interested in contributing please visit our [Contributors guide](/tech/contributing) which contains information on [contributing to SEEK](/tech/contributing-to-seek) or [reporting a bug or feature request](/tech/reporting-bugs-and-features).
+If you are interested in contributing please visit our [Contributors guide]({{ site.baseurl }}/tech/contributing) which contains information on [contributing to SEEK]({{ site.baseurl }}/tech/contributing-to-seek) or [reporting a bug or feature request]({{ site.baseurl }}/tech/reporting-bugs-and-features).
 
 

--- a/tech/install.md
+++ b/tech/install.md
@@ -6,7 +6,7 @@ redirect_from: "/install.html"
 
 ## Introduction
 
-These steps describe how to install SEEK directly on the machine (_bare-metal_). 
+These steps describe how to install SEEK directly on the machine (_bare-metal_).
 
 Docker is also supported, which in many cases is simpler and quicker, please read the [Docker Compose guide](docker/docker-compose).
 
@@ -15,7 +15,7 @@ short, optional [SEEK Registration
 Form](https://seek4science.org/seek-registration)
 
 If you have any problems or questions, you should contact us. The following
-link will give you details on how to [Contact Us](/contacting_us)
+link will give you details on how to [Contact Us]({{ site.baseurl }}/contacting_us)
 
 SEEK is based upon the Ruby on Rails platform. Although the information on
 this page should provide you with everything you need to get a basic
@@ -69,11 +69,11 @@ Installing these packages now will make installing Ruby easier later on:
 
     sudo apt install autoconf automake bison curl gawk libffi-dev libgdbm-dev \
         libncurses5-dev libsqlite3-dev libyaml-dev sqlite3
-        
+
 SEEK's Solr implementation currently requires Java 11, so you may need to switch the system's default Java runtime:
 
     sudo update-alternatives --config java
-    
+
 ...and select the version named `/usr/lib/jvm/java-11-openjdk-amd64/bin/java` or similar.
 
 ## Development or Production?
@@ -151,7 +151,7 @@ First, a specific version of `setuptools` needs to be installed to avoid an issu
 Then the other dependencies can be installed
 
     python3.9 -m pip install -r requirements.txt
-    
+
 
 ## Setting up the Database
 
@@ -165,7 +165,7 @@ default version of this and then edit it:
 Change this for each environment (development,production,test).
 
 Now you need to grant permissions for the user and password you just used
-(changing the example below appropriately). 
+(changing the example below appropriately).
 
     > sudo mysql
     Enter password:
@@ -199,7 +199,7 @@ Production](install-production) guide for automating these services.
 
 ### Setting up and starting the Search Service
 
-SEEK uses the [Apache Solr Search Engine](https://solr.apache.org/) which since SEEK v1.12 needs setting up 
+SEEK uses the [Apache Solr Search Engine](https://solr.apache.org/) which since SEEK v1.12 needs setting up
 separately. It is relatively straightforward and there are instructions on how to do this in [Setting Up Solr](setting-up-solr).
 
 ### Starting and Stopping the Background Service

--- a/tech/openseek.md
+++ b/tech/openseek.md
@@ -10,7 +10,7 @@ openBIS can be download and installed from the [openBIS download page](https://w
 
 
 
-    
+
 ## Using SEEK and openBIS
-    
-For further instructions on how to use SEEK with openBIS please read our [User Guide page for openBIS](/help/user-guide/openbis).    
+
+For further instructions on how to use SEEK with openBIS please read our [User Guide page for openBIS]({{ site.baseurl }}/help/user-guide/openbis).

--- a/tech/releases/index.md
+++ b/tech/releases/index.md
@@ -5,9 +5,9 @@ title: FAIRDOM-SEEK releases
 {% capture latest_version_long %}Latest version - {{ site.current_seek_version }}{% endcapture %}
 {% include callout.html type="note" content=latest_version_long %}
 
-Please see [Getting FAIRDOM-SEEK](/get-seek) for details about installing SEEK.
+Please see [Getting FAIRDOM-SEEK]({{ site.baseurl }}/get-seek) for details about installing SEEK.
 
-If you have any comments or feedback about a release, then please [Contact Us](/contacting-us).
+If you have any comments or feedback about a release, then please [Contact Us]({{ site.baseurl }}/contacting-us).
 
 ## Version 1.16.1
 
@@ -49,7 +49,7 @@ A major release that contains a number of improvements, upgrades and bug fixes, 
       which are then automatically applied.
     * _This is currently an experimental feature_, disabled by default (but can be enabled in the settings), with
       documentation planned, and also automatic creation of Extended Metadata Types, tighter coupling through API's and
-      [RO-Crate](https://www.researchobject.org/ro-crate/) support. 
+      [RO-Crate](https://www.researchobject.org/ro-crate/) support.
 * **Explicit Sample Type permissions** - previously, Sample Type visibility was automatically derived according to the
   Projects it is shared with and the visibility of related Samples.
   This has now been updated to allow the permissions to be explicitly defined and under user control. When upgrading
@@ -59,11 +59,11 @@ A major release that contains a number of improvements, upgrades and bug fixes, 
   ability to change the attributes was limited.
   This has been relaxed to allow some changes to be made that won't invalidate existing Samples, including adding new
   optional attributes, changing attributes from required to options, the title attribute, the attribute pid and
-  description, and changing the name of an attribute. 
+  description, and changing the name of an attribute.
 * **Creating new Extended Metadata Types** - an instance administrator of SEEK can now create new Extended Metadata
   Types through the user interface, using a simple JSON file that defines the type and attributes.
-  The JSON has a corresponding [schema](/tech/extended-metadata/extended-metadata-type-schema.json) against which it is
-  validated. There is new [extensive Documentation](/tech/extended-metadata/extended-metadata-type) including on
+  The JSON has a corresponding [schema]({{ site.baseurl }}/tech/extended-metadata/extended-metadata-type-schema.json) against which it is
+  validated. There is new [extensive Documentation]({{ site.baseurl }}/tech/extended-metadata/extended-metadata-type) including on
   on how to create, and we are also planning on supporting doing so with an Excel template.
 * **Deleting Extended Metadata Types** - in addition to being able to disable, an administrator is now able to delete
   Extended Metadata Types.
@@ -109,7 +109,7 @@ A patch release that includes some important bug fixes and improvements, in part
 * Fix to correctly transfer Sample sharing policies from the originating Data file when extracted.
 * Fix to the page shown when starting to import a DMP.
 * Better error handing and reporting when BiVeS model comparison fails.
-* Various small fixes and improvements, regarding Experiment Sample Templates and the Single Page View. 
+* Various small fixes and improvements, regarding Experiment Sample Templates and the Single Page View.
 
 For a full list, see [closed issues for 1.15.1](https://github.com/seek4science/seek/milestone/22?closed=1)
 
@@ -121,17 +121,17 @@ A major release that contains a number of improvements, upgrades and bug fixes, 
 
 * **Licenses** have now been updated to be linked to [SPDX license identifiers](https://spdx.org/licenses/), with support for more open source licences.
 * A **sitemap.xml** is generated for all public content, improving indexing by the main search engines, and support for Bioschemas scraping.
-* **Extracted Samples** originating from a Sample type template DataFile are now editable and have their own sharing policies and 
+* **Extracted Samples** originating from a Sample type template DataFile are now editable and have their own sharing policies and
   associated projects (previously these were bound to the source datafile).
 * **Duplicate Samples** that occur when extracted from a template are now detected and warning is given.
 * **Samples that link to a DataFile** through one of the Sample attributes are now shown as related items, and vice versa.
 * **Allowing free text for Controlled Vocabulary** sample attributes, which can be set as allowed for the attribute as part of a defined Sample Type.
 * **Controlled Vocabulary performance improvements**, both the user interface and backend, to allow one to be populated from a large number of terms from an ontology.
-* **Ontology based Controlled Vocabulary's** can now be populated from **multiple root nodes** of the ontology hierarchy.  
+* **Ontology based Controlled Vocabulary's** can now be populated from **multiple root nodes** of the ontology hierarchy.
 * **Performance improvements when viewing Data files** - a check for matching sample types was previously slowing things down, this now happens less often and asynchronously.
 * **Performance improvements when deleting items**, especially large numbers of samples deleted at the same time as the source DataFile.
 * **Performance improvements** to several of the **background jobs** that run, and also optimisations to the order and priority that they run and number that get created.
-* Improvements to the deletion of content-blobs (which describe the registered files) and protection against them being reused after deletion.  
+* Improvements to the deletion of content-blobs (which describe the registered files) and protection against them being reused after deletion.
 * UI improvements for selecting Projects and Institutions for sharing permissions, making them searchable and easier to find in a long list.
 * **Automatic approval of Project requests** for the site-managed programme can now be set as a configuration option.
 * **[RDA Data Management Plan Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard) support**, which can now be used to populate a Project.
@@ -144,7 +144,7 @@ A major release that contains a number of improvements, upgrades and bug fixes, 
 * **Extended Metadata Type administration** has been added to the Admin pages, currently just allowing them to be disabled or enabled but with plans to extend this with other option in future releases.
 * **Wild cards in search queries** are now supported, supporting _'*'_ for a group of characters, and _'?'_ for a single character. e.g _'[?orwe*n](https://fairdomhub.org/institutions?filter%5Bquery%5D=%3Forwe%2An)'_ to match Norwegian.
 * **Mysql 8 is now the recommended database** to use, and our default Docker compose files have been updated and tested, together with testing switching existing installations. Mysql 5.7 had an issue with reusing primary keys after a crash, causing some problems in certain scenarios.
-* **More control over Docker logging** is now available as an option with environment variables, with the default and comment added to the Docker compose files.  
+* **More control over Docker logging** is now available as an option with environment variables, with the default and comment added to the Docker compose files.
 * [DataHub](https://datahub.elixir-belgium.org/home/about) is now approaching its first production release, and this version includes two particular hightlights:
     * **Single Page view** for visualising experiments.
     * Creation of **ISA-JSON compliant experiments** using Experiment Sample Templates.
@@ -176,7 +176,7 @@ A patch release that includes some important bug fixes and improvements:
 * Fixed a problem that prevented extracted samples that include links to other samples being successfully registered.
 * Fixed an error that was occurring when a sample attrribute PID was inadvertently set to an invalid IRI.
 * A fix to some cases where the submit button was always disabled when attempting to "Request membership" to a Project.
-* The integration with the Ontology Lookup Service has been updated to use version 4. 
+* The integration with the Ontology Lookup Service has been updated to use version 4.
 * The sample attribute type "Registered Sample (multiple)" has been renamed "Registered Sample List" to be consistent with other types.
 * The sample attribute type "Ontology" has been removed, as it was just duplicate of "Controlled Vocabulary". We are looking at ways to distinguish between
 plain CV's and ontology based CV's in the UI.
@@ -190,13 +190,13 @@ Release date: _12th October 2023_
 
 A major release that contains a number of improvements, upgrades and bug fixes, including:
 
-* **Upgrade of Ruby**, from Ruby 2.7 to Ruby 3.1. 
+* **Upgrade of Ruby**, from Ruby 2.7 to Ruby 3.1.
   * This gives improved speed and overall performance, along with keeping up with security patches.
-* **Upgrade to Rails**, to the latest 6.1 release.  
-* **Nested [Extended Metadata](/tech/extended-metadata)** (previously referred to as Custom Metadata).
+* **Upgrade to Rails**, to the latest 6.1 release.
+* **Nested [Extended Metadata]({{ site.baseurl }}/tech/extended-metadata)** (previously referred to as Custom Metadata).
     * Extended Metadata allows items to be customized with additional typed metadata, similar to samples, and was used to support MIAPPE along
-    with some bespoke installations. 
-    * Extended Metadata can now be nested, i.e one Extended Metadata type definition can include a reference to another, 
+    with some bespoke installations.
+    * Extended Metadata can now be nested, i.e one Extended Metadata type definition can include a reference to another,
       and these will be nested together in a single form.
     * The inner Extended Metadata type can also now be defined as a list, with the form allowing new items to be added or removed.
 * **Gatekeeper behaviour** refresh and fixes
@@ -207,14 +207,14 @@ A major release that contains a number of improvements, upgrades and bug fixes, 
     and have them applied correctly when approved.
   * Users can now cancel a publishing request.
   * Added support for Samples.
-  * Improved integration with DataHub and the Single Page View.  
-  * Updated [documentation](/help/user-guide/roles.html#asset-gatekeeper).  
+  * Improved integration with DataHub and the Single Page View.
+  * Updated [documentation]({{ site.baseurl }}/help/user-guide/roles.html#asset-gatekeeper).
 * **Viewing of Excel files in the browser** for all asset types (previously only Data Files were supported).
 * **Event filtering improvements**.
   * Includes the full set of common filters available for other items, plus the addition of Event specific filters.
 * **Fix duplications in the ISA graph and tree**, particularly for publications.
 * **Updated and unified auto complete text fields** to use an improved UI component and be consistent throughout.
-  * Type ahead fields that autocomplete (e.g. tagging, sample controlled vocabularies) have now been updated to use [select2](https://select2.org/) throughout.   
+  * Type ahead fields that autocomplete (e.g. tagging, sample controlled vocabularies) have now been updated to use [select2](https://select2.org/) throughout.
 * **Programme creation request notifications** to adminstrators are now shown in the browser as well as by email.
 * **Explanatory text for Programme creation** has been provided.
 * **Navigating from broad search results across all types, to the full list** with filtering for a specific type has been made clearer .
@@ -240,9 +240,9 @@ A small patch release that contains some small bug fixes:
 
 * Fix for handling redirects correctly when registering an item by URL.
 * Fix to handle items registered as a remote URL - when the URL needs authorization it is always shown as an external link.
-* Fix for a missing python dependency (filelock), which is required for processing CWL workflows. 
+* Fix for a missing python dependency (filelock), which is required for processing CWL workflows.
 
-We have also provided details about [installing Ruby 2.7 on Ubuntu 22.04](/tech/ruby-2.7-ubuntu-22.04). 
+We have also provided details about [installing Ruby 2.7 on Ubuntu 22.04]({{ site.baseurl }}/tech/ruby-2.7-ubuntu-22.04).
 
 For a full list, see [closed issues for 1.13.4](https://github.com/seek4science/seek/milestone/18?closed=1)
 
@@ -273,7 +273,7 @@ A small patch release that contains several bug fixes and small improvements, in
 * A new Sample attribute type, _Controlled Vocabulary List_, that supports multiple terms selected from a Controlled Vocabulary as an array
 * Fix to correctly provide the content length in HTTP headers for downloads that was missing in some cases, and also added the Content-MD5 header to include the md5 checksum
 * Programmes are now listed in MyItems, and related items generally, if the user is the Programme Administrator but not directly a member of a related Project
-* Space out daily background jobs so that they don't all run at once, avoiding potential memory issues  
+* Space out daily background jobs so that they don't all run at once, avoiding potential memory issues
 * Upgrade of Rails to the 6.1.7.2 version, and also Ruby to the 2.7.8 version
 
 For a full list, see [closed issues for 1.13.2](https://github.com/seek4science/seek/milestone/15?closed=1)
@@ -293,7 +293,7 @@ For a full list, see [closed issues for 1.13.1](https://github.com/seek4science/
 
 ## Version 1.13.0
 
-Release date: _12th January 2023_ 
+Release date: _12th January 2023_
 
 A major release with broad number of changes, including many small changes and bug fixes not listed here.
 The high level changes include:
@@ -372,7 +372,7 @@ Small release with some bugfixes and small improvements. In particular a securit
 
 * An overhaul and refresh of Gatekeeper behaviour, fixing bugs and allowing repeat requests to be sent following a previous rejection.
 * Fix to an error when interacting with the Ontology Lookup Service API, which affected creating and using sample types and controlled vocabularies in some cases.
-* More tolerant URL checking when registering a remote asset. 
+* More tolerant URL checking when registering a remote asset.
 * Removed option to generate a DOI for a hidden version.
 
 For a full list, see [closed issues for 1.12.1](https://github.com/seek4science/seek/milestone/9?closed=1)
@@ -458,7 +458,7 @@ A small update release with a few small changes and bug fixes, in particular:
 
   * Fix to a rarely encountered bug that caused a user to be added to a project with a nil Institution, which could then lead to other problems
   * Fix to remove some warning messages about a duplicate definition of _include_blank_
-  * Person responsible for Study has been deprecated and removed from the user interface 
+  * Person responsible for Study has been deprecated and removed from the user interface
 
 For a full list, see  [closed issues for 1.11.1](https://github.com/seek4science/seek/milestone/5?closed=1)
 
@@ -468,49 +468,49 @@ Release date: _21st June 2021_
 
 This version includes:
 
-  * **Changes to joining a project during registration**. 
-    * During registration a user will no longer be asked to select a Project and Institution, (this was often missed). Instead, they will be prompted to either Join or Create a Project after registration and until they are a member. 
-    * [Joining a Project](/help/user-guide/join-a-project.html) now has an easier interface to search and select the projects the users want to join, and to define either a new Institution or select an existing one
+  * **Changes to joining a project during registration**.
+    * During registration a user will no longer be asked to select a Project and Institution, (this was often missed). Instead, they will be prompted to either Join or Create a Project after registration and until they are a member.
+    * [Joining a Project]({{ site.baseurl }}/help/user-guide/join-a-project.html) now has an easier interface to search and select the projects the users want to join, and to define either a new Institution or select an existing one
     * The Project administrator is notified by email, and is provided with a single page to accept the join request more easily, and is also prompted through the FAIRDOM-SEEK interface if there are outstanding requests.
-  * **Simplified Project and Programme creation.** 
-    * A user can now more easily request to [create a Project](/help/user-guide/create-a-project.html). The Project creation request can include a Programme if enabled, along with defining a new Institution or selecting an existing one. 
+  * **Simplified Project and Programme creation.**
+    * A user can now more easily request to [create a Project]({{ site.baseurl }}/help/user-guide/create-a-project.html). The Project creation request can include a Programme if enabled, along with defining a new Institution or selecting an existing one.
     * If a Programme or site administrator is needed to approve the request, there is a simpler interface to accept or reject quickly, and the administrators are prompted through the FAIRDOM-SEEK interface as well as email.
-  * **Site managed Programme.** 
+  * **Site managed Programme.**
     * FAIRDOM-SEEK can now configured to include a site managed Programme.
     * This can be selected by users who do not want to a Programme to self administer and add additional Projects.
-  * **Markdown formatting of descriptions.** 
-    * Support has been added for [markdown elements in descriptions](/help/user-guide/general-attributes#description).
+  * **Markdown formatting of descriptions.**
+    * Support has been added for [markdown elements in descriptions]({{ site.baseurl }}/help/user-guide/general-attributes#description).
     * It includes an editor with shortcuts for common formatting options, together with a preview option.
-  * **Ontology based controlled vocabularies.** 
+  * **Ontology based controlled vocabularies.**
     * FAIRDOM-SEEK now supports Sample attributes limited to controlled vocabularies (CVs) backed by an ontology.
     * This extends the current capability for a controlled vocabulary to be specified by a list of strings.
     * The ontology backed CV's can be easily populated in the User Interface via the Ontology Lookup Service. They may also be populated manually with Internationalized Resource Identifiers (IRI's).
-  * **Spreadsheet view for exploring Comma and Tab separated value files (CSV or TSV).** 
+  * **Spreadsheet view for exploring Comma and Tab separated value files (CSV or TSV).**
     * FAIRDOM-SEEK adds support for exploring CSV/TSV files uploaded as a DataFile.
     * The exploration presents a table view of data.
     * The exploration extends the existing Excel file explore feature.
-  * **Condensed view of lists.** 
-    * When viewing the standard index page for items, FAIRDOM-SEEK now has an alternative  [condensed view](/help/user-guide/browsing.html) that can be selected.
+  * **Condensed view of lists.**
+    * When viewing the standard index page for items, FAIRDOM-SEEK now has an alternative  [condensed view]({{ site.baseurl }}/help/user-guide/browsing.html) that can be selected.
     * The condensed view has collapsible items, that make it easier to view and browse more results in a single results page.
-  * **Table view of lists.** 
-    * When viewing the standard index page for items, there is now an alternative view that can displays [items in a table](/help/user-guide/browsing.html).
+  * **Table view of lists.**
+    * When viewing the standard index page for items, there is now an alternative view that can displays [items in a table]({{ site.baseurl }}/help/user-guide/browsing.html).
     * By default, a small set of columns of data about the items are shown. This set can be extended and customised to include attributes related to that item type.
-  * **MIAPPE support with custom metadata extensions.** 
+  * **MIAPPE support with custom metadata extensions.**
     * FAIRDOM-SEEK now adds the ability to extend entities with additional metadata attributes. The focus is currently on extending metadata for Investigations, Studies and Assays to support [MIAPPE](https://github.com/MIAPPE/MIAPPE).
     * The ability is generic and can be used to define custom metadata extensions for any item type; this allows FAIRDOM-SEEK to support different standards.
-    * Future versions plan to provide 
+    * Future versions plan to provide
       * a UI to allow the  definition of new extensions,
       * pre-defined definitions for repository standards, and also
       * support for MIAPPE observed variables.
-  * **Bulk changing of sharing permissions.** 
-    * FAIRDOM-SEEK 1.11 adds the ability to [bulk change the sharing permissions](/help/user-guide/bulk-change-sharing-permission.html) of many items in a single step.    
-  * **Simplified deleting of Projects.** 
+  * **Bulk changing of sharing permissions.**
+    * FAIRDOM-SEEK 1.11 adds the ability to [bulk change the sharing permissions]({{ site.baseurl }}/help/user-guide/bulk-change-sharing-permission.html) of many items in a single step.
+  * **Simplified deleting of Projects.**
     * FAIRDOM-SEEK now allows the deletion of Projects by the Project administrator, even if the project still has members.
     * The members will automatically be removed
     * Projects that contain assets or Investigations, Studies or Assays cannot be deleted without first removing them.
-  * **Run with Copasi button.** 
-    * Added ability to download a publicly downloadable model to a local installed Copasi application and to start the simulation in Copasi 
-  * **Changing visibility of item versions.** 
+  * **Run with Copasi button.**
+    * Added ability to download a publicly downloadable model to a local installed Copasi application and to start the simulation in Copasi
+  * **Changing visibility of item versions.**
     * Historically past versions of an item have been visible to registered users, but not to those logged out (anonymous).
     * FAIRDOM-SEEK now supports all past versions being visible (in accordance with the sharing permissions of the item),
     * The visibility of specific versions can be controlled by the user - completely hiding individual versions if wished.
@@ -528,8 +528,8 @@ This version includes the following bugfixes:
   * Fixes to doing a search over filtered results, and maintaining the correct order from the search results
   * Adding new version comments for Documents
   * Fix to Dataset schema.org markup
-  
-[Closed issues for 1.10.3](https://github.com/seek4science/seek/milestone/4?closed=1)  
+
+[Closed issues for 1.10.3](https://github.com/seek4science/seek/milestone/4?closed=1)
 
 ## Version 1.10.2
 
@@ -537,18 +537,18 @@ Release date: _28th August 2020_
 
 This version includes a few bugfixes:
 
-  * A fix to a validation error when linking to a older publication with no publication type defined. 
+  * A fix to a validation error when linking to a older publication with no publication type defined.
   * A fix to adding via a URL, where the remote server doesn't respond to HEAD requests.
   * Better handling of when the attr_encrypted key is missing or wrong, which previously prevented the server starting up.
   * A fix to activity reporting, where a snapshot pointed to a deleted resource.
 
-[Closed issues for 1.10.2](https://github.com/seek4science/seek/milestone/3?closed=1)  
+[Closed issues for 1.10.2](https://github.com/seek4science/seek/milestone/3?closed=1)
 
 ## Version 1.10.1
 
 Release date: _24th June 2020_
 
-This version contains a few bug fixes and security updates, and minor feature additions. 
+This version contains a few bug fixes and security updates, and minor feature additions.
 In particular:
 
   * Rails upgrade to the latest Rails 5 release (5.2.4.3), along with some other dependencies
@@ -573,7 +573,7 @@ Highlights:
     * It is also possible to perform a text search over the list, and apply filters to the results
     * Filters across categories have **AND** applied, whereas within a category **OR** is applied
   * Enhanced support for publications:
-    * Support for more publication types, including:  _Journal article_, _inproceedings_, _inbook_, etc. 
+    * Support for more publication types, including:  _Journal article_, _inproceedings_, _inbook_, etc.
     Users can update the publication type when editing the publication.
     * Additional metadata attributes including _booktitle_, _editor_, _publisher_, _a remote URL_
     * For publications, which are manually registered or imported from bibtex files, users can edit all fields of publications.
@@ -581,7 +581,7 @@ Highlights:
     * Improvements to importing publications by a bibtex file
       * Ability to import different types of publications
       * Add more validations to support different types of publications
-      * Generate the citation according to the type of publications when there is no DOI or Pubmed ID   
+      * Generate the citation according to the type of publications when there is no DOI or Pubmed ID
   * Adding one or more Discussion Channel links to all Assets
     * If you wish to provide the ability to open a discussion about an item, one or more links can be added to locations
     such as Slack, GitHub issue, a Forum thread
@@ -589,14 +589,14 @@ Highlights:
   * Increased zoom level when previewing model images, and ability to view the original in its full resolution
   * Support for 'include' when using the JSON API
     * Allows you to get full details about related resources in a single call ( see [JSONAPI specification](https://jsonapi.org/format/#fetching-includes))
-    * For example <https://fairdomhub.org/projects/19.json?include=people> expands information about the people in an _included[]_ block at the end of the top level JSON. 
+    * For example <https://fairdomhub.org/projects/19.json?include=people> expands information about the people in an _included[]_ block at the end of the top level JSON.
   * Study Experimentalists attribute has been deprecated - existing entries aren't lost and can be edited, but the attribute has been removed
-  for new entries or existing entries where that attribute hasn't been set 
+  for new entries or existing entries where that attribute hasn't been set
   * Renaming of _contributor_ to _submitter_ - to be clearer about what this attribute represents
-  * Update of [BiVeS](https://semsproject.github.io/BiVeS/) - used for model version comparisons, has been updated to the latest available version  
-    
-  
-There have also been many other minor bug fixes and improvements.  
+  * Update of [BiVeS](https://semsproject.github.io/BiVeS/) - used for model version comparisons, has been updated to the latest available version
+
+
+There have also been many other minor bug fixes and improvements.
 
 _Note_ that with this version, we moved from JIRA to [Github Issues](https://github.com/seek4science/seek/issues), and
 for this and probably future versions have stopped providing links to individual tasks.
@@ -617,8 +617,8 @@ Release date: _17th October 2019_
   * Validating assay and technology type URI's (particularly when submitting through the API).
   * Managing project members through the API.
   * Fix to an problem and inconsistency with how countries and the country codes are stored and displayed
-  
-There have also been several minor bug fixes and improvements, 
+
+There have also been several minor bug fixes and improvements,
 which are described more within the [SEEK v1.9.1 release notes](release-notes-1.9.1.html)
 
 ## Version 1.9.0
@@ -629,14 +629,14 @@ Release date: _16th July 2019_
     * Rails 4.2 → Rails 5.2
     * Updating and replacing affected libraries and dependencies
     * Unifying javascript to use jQuery framework throughout, and removing Prototype references
-  * A lot of bugfixes and minor improvements discovered during the upgrade testing  
+  * A lot of bugfixes and minor improvements discovered during the upgrade testing
   * Ability to login with email as well as username
   * Ability to edit previous version revision comments
   * Show the SEEK ID of the selected node when navigating the ISA overview
   * Fix for model files appearing missing for previous versions (don't worry, no files were actually lost)
 
 
-Changes are also described in the [SEEK v1.9.0 release notes](release-notes-1.9.0.html). 
+Changes are also described in the [SEEK v1.9.0 release notes](release-notes-1.9.0.html).
 Please note that many of the bugfixes are those created during the Rails upgrade,
 due to changes in the Rails version.
 
@@ -650,7 +650,7 @@ Bug fix release:
    * Additional constraints to prevent invalid permissions, particularly when changing through the API
    * Fix to finding related Organisms to a Sample through an NCBI ID attribute
 
-Changes are also described in the [SEEK v1.8.3 release notes](release-notes-1.8.3.html)         
+Changes are also described in the [SEEK v1.8.3 release notes](release-notes-1.8.3.html)
 
 ## Version 1.8.2
 
@@ -661,8 +661,8 @@ Bug fixes and minor improvements, changes are:
    * Fix to a potential database lock, particularly when registering multiple items in quick succession through the API
    * Ability to edit version revision comments
    * Fix to correctly show the creator of a particular DataFile version
-   
-Changes are also described in the [SEEK v1.8.2 release notes](release-notes-1.8.2.html)   
+
+Changes are also described in the [SEEK v1.8.2 release notes](release-notes-1.8.2.html)
 
 ## Version 1.8.1
 
@@ -672,7 +672,7 @@ Bug fixes and minor improvements, main fixes are:
 
   * Fix to some cases where the RDF wasn't including associated assets
   * Better handling of news feed errors, and avoid cases where they could prevent the front page loading
-  * Fixed the order publication authors are displayed in list items  
+  * Fixed the order publication authors are displayed in list items
   * Project Dashboard help link
 
 A full list of changes included in this release can be found in the [SEEK v1.8.1 release notes](release-notes-1.8.1.html)
@@ -681,16 +681,16 @@ A full list of changes included in this release can be found in the [SEEK v1.8.1
 
 Release data: _February 12th 2019_
 
-  * **openBIS integration** has been extended and improved upon, mainly through contributions from [Tomasz Zielinski](https://fairdomhub.org/people/711) 
+  * **openBIS integration** has been extended and improved upon, mainly through contributions from [Tomasz Zielinski](https://fairdomhub.org/people/711)
   of [SynthSys](https://fairdomhub.org/programmes/21). The extensions include linking between Studies and openBIS Experiments, and Assays and openBIS Objects.
-  Automation has also been added to automatically detect and synchronise new items. For more information please read our [Guide for using openBIS with SEEK](/help/user-guide/openbis.html).
-  **Note** that to use the new features, [openBIS 18.06.1 or later](https://wiki-bsse.ethz.ch/display/bis/openBIS+Download+Page) is required. 
-  * A new **Project Dashboard** has been added, to allow project members to view various statistics and trends, including graphs, within their project. 
-  For more information please read the [Project Dashboard Guide](/help/user-guide/project-dashboard.html) 
+  Automation has also been added to automatically detect and synchronise new items. For more information please read our [Guide for using openBIS with SEEK]({{ site.baseurl }}/help/user-guide/openbis.html).
+  **Note** that to use the new features, [openBIS 18.06.1 or later](https://wiki-bsse.ethz.ch/display/bis/openBIS+Download+Page) is required.
+  * A new **Project Dashboard** has been added, to allow project members to view various statistics and trends, including graphs, within their project.
+  For more information please read the [Project Dashboard Guide]({{ site.baseurl }}/help/user-guide/project-dashboard.html)
   * **Former project members**, that have been marked as inactive within a project, are now more clearly indicated along with the date they left.
   * **Project start and end dates** can now be defined for a project, which, if defined, are displayed on the Project page.
-        
-A full list of changes included in this release can be found in the [SEEK v1.8.0 release notes](release-notes-1.8.0.html)   
+
+A full list of changes included in this release can be found in the [SEEK v1.8.0 release notes](release-notes-1.8.0.html)
 
 ## Version 1.7.1
 
@@ -699,22 +699,22 @@ Release date: _November 19th 2018_
   * Fix to a bug where the session table column was too small. This sometimes led to a datafile upload problem if the user was in a large number of projects.
   * Show the Project creation date on its _show_ page. (In 1.8 we plan to include the option to specify the project start and end dates).
   * Fix to a bug where some assets couldn't be edited if shared across multiple projects, and the user only belonged to a subset of those projects.
-     
-A full list of changes included in this release can be found in the [SEEK v1.7.1 release notes](release-notes-1.7.1.html)     
+
+A full list of changes included in this release can be found in the [SEEK v1.7.1 release notes](release-notes-1.7.1.html)
 
 ## Version 1.7.0
 
 Release date: _October 15th 2018_
 
   * **Programme wide sharing permissions** have been added.  The sharing options now include the ability to share across a whole Programme.
-  * **ISA graph improvements** - we spent some time revisiting the ISA graph, fixing some underlying issues and making it more usable. It now defaults to showing the tree view, and 
-  the graphical view is simplified and highlights the current item and its nearest neighbours. It no longer includes the associated Project and Programmes to avoid unnecessary interlinking 
-  and complexity. The intention is that the graph view should provide a quick visual indication of the place of the current item within the ISA network, and provide the ability to explore and navigate 
-  over the graph. A separate export function has been provided to all easy generation and download of PNG files for inclusion in reports or presentations. 
-  * A dedicated **NCBI ID sample attribute type** has been added, which accepts a number and displays as an identifier URI. If the NCBI id matches an Organism present in SEEK then the link will automatically be made.   
-  * Restrictions to **Sample Type visibility** have been added. Sample types are now initially only visible to members of the Project they are associated with, until it starts having Samples associated with it. 
+  * **ISA graph improvements** - we spent some time revisiting the ISA graph, fixing some underlying issues and making it more usable. It now defaults to showing the tree view, and
+  the graphical view is simplified and highlights the current item and its nearest neighbours. It no longer includes the associated Project and Programmes to avoid unnecessary interlinking
+  and complexity. The intention is that the graph view should provide a quick visual indication of the place of the current item within the ISA network, and provide the ability to explore and navigate
+  over the graph. A separate export function has been provided to all easy generation and download of PNG files for inclusion in reports or presentations.
+  * A dedicated **NCBI ID sample attribute type** has been added, which accepts a number and displays as an identifier URI. If the NCBI id matches an Organism present in SEEK then the link will automatically be made.
+  * Restrictions to **Sample Type visibility** have been added. Sample types are now initially only visible to members of the Project they are associated with, until it starts having Samples associated with it.
   The Sample Type will become visible outside of the project, and to external users, once one or more samples associated with that Sample type have been made public. This allows more freedom to allow all project members to create
-  Sample Types, without the difficulties of having full sharing permissions on Sample types, whilst restricting the Sample Types exposed outside of the Project. 
+  Sample Types, without the difficulties of having full sharing permissions on Sample types, whilst restricting the Sample Types exposed outside of the Project.
   * The ability to link **Documents to Events**, and vice versa, has been added.
 
 A full list of changes included in this release can be found in the [SEEK v1.7.0 release notes](release-notes-1.7.0.html)
@@ -723,7 +723,7 @@ A full list of changes included in this release can be found in the [SEEK v1.7.0
 
 Release date: _August 21st 2018_
 
-  * Fix to prevent users flagged as having left a project being able to access items shared with that project 
+  * Fix to prevent users flagged as having left a project being able to access items shared with that project
   (they can still access their own items, or items also shared within them in other ways)
   * Fix to an error occuring when a large number of Documents are associated with an Assay
   * Fix to manually adding an organism manually through its NCBI ID, when the ID URL is provided with surrounding spaces.
@@ -738,8 +738,8 @@ Release date: _July 5th 2018_
   * Fixed a bug when viewing a Project page that has more that 5 visible Documents associated with it.
   * Avoid warning about missing projects when uploading a standard Excel file, being mistaken as RightField template.
   * When running SEEK through Docker, write the Puma output and error logs to files.
-  
-A full list of changes included in this release can be found in the [SEEK v1.6.2 release notes](release-notes-1.6.2.html).  
+
+A full list of changes included in this release can be found in the [SEEK v1.6.2 release notes](release-notes-1.6.2.html).
 
 ## Version 1.6.1
 
@@ -751,13 +751,13 @@ Bugfixes and some small improvements, in particular
   * Fixed a mime type problem when uploading files, in particular CSV files being incorrectly treated as Excel
   * When using the DataFile upload wizard, the arrow keys no longer affect navigation whilst editing a field
   * Recognise and handle Excel (macro-enabled), XLSM, files as standard Excel files.
-  * Within the admin area, when showing the queued jobs, there is no a button to clear failed jobs. 
+  * Within the admin area, when showing the queued jobs, there is no a button to clear failed jobs.
   * You no longer have to accept the (blank) Terms and Conditions when setting up the first user for a new SEEK installation.
-  
-There have also been a few other smaller fixes and improvements, a full list of changes included in this release can be found in 
+
+There have also been a few other smaller fixes and improvements, a full list of changes included in this release can be found in
 the [SEEK v1.6.1 release notes](release-notes-1.6.1.html).
-                                                                  
- 
+
+
 
 ## Version 1.6.0
 
@@ -765,28 +765,28 @@ Release date: _June 8th 2018_
 
 Major changes include:
 
-  * Interlinking the [**ELIXIR Norwegian e-Infrastructure for Life Sciences (NeLS)**](https://nels.bioinfo.no/) with the SEEK platform. 
- This will provide NeLS and SEEK users with unprecedented opportunities for storing, sharing, 
+  * Interlinking the [**ELIXIR Norwegian e-Infrastructure for Life Sciences (NeLS)**](https://nels.bioinfo.no/) with the SEEK platform.
+ This will provide NeLS and SEEK users with unprecedented opportunities for storing, sharing,
  and archiving of data in ways that comply with the FAIR principles.
-  * Our second installment of our [**JSON API**](/help/user-guide/api.html), in particular to include support for **writing** and submitting new entries in SEEK. 
-    Most write abilities are now available through the API including creating Datafiles, SOPs, Models, 
-    Investigation, Studies and Assays and linking them together. More details about the api can be found in the 
-    [API Guide](/help/user-guide/api.html), with more technical details found in the [JSON API Overview](/tech/api/index.html) 
-  * Changes to the  **DataFiles upload workflow**, along with better RightField template support. The flow has been changed such that the 
+  * Our second installment of our [**JSON API**]({{ site.baseurl }}/help/user-guide/api.html), in particular to include support for **writing** and submitting new entries in SEEK.
+    Most write abilities are now available through the API including creating Datafiles, SOPs, Models,
+    Investigation, Studies and Assays and linking them together. More details about the api can be found in the
+    [API Guide]({{ site.baseurl }}/help/user-guide/api.html), with more technical details found in the [JSON API Overview]({{ site.baseurl }}/tech/api/index.html)
+  * Changes to the  **DataFiles upload workflow**, along with better RightField template support. The flow has been changed such that the
  file is registered before providing additional details. This allows information to be extracted and details automatically populated where
  possible. The supported templates are now provided as part of the templates generated for Sample Types, but will soon be available more widely.
-  * DataFile metadata is now provided through a [**Wizard**](/help/user-guide/data-file-upload-wizard.html), split into logical steps, that can easily be stepped through.
+  * DataFile metadata is now provided through a [**Wizard**]({{ site.baseurl }}/help/user-guide/data-file-upload-wizard.html), split into logical steps, that can easily be stepped through.
   * Assays can be created and linked to the DataFile being submitted as part of the same process. This can either be manual or from the details provided within
  a template.
   * Support for a new **Document** asset type. This is to represent general documents that do not fit as other asset types - such as
-  reports or meeting minutes.     
+  reports or meeting minutes.
   * Ability to enable and provide **Terms and Conditions**, that need to be accepted as part of the registration process
-  * Creating **DOI's** for individual items has been made clearer and easier to use.    
+  * Creating **DOI's** for individual items has been made clearer and easier to use.
 
 There have also been many other bug fixes and small improvements.
 A full list of changes included in this release can be found in the [SEEK v1.6.0 release notes](release-notes-1.6.0.html).
- 
- 
+
+
 ## Version 1.5.2
 
 Release date: _February 20th 2018_
@@ -797,7 +797,7 @@ Bugfix release that includes:
   * Image scaling fix - where some avatars were scaled down, and then expanded causing them to appear blurred.
 
 A full list of changes included in this release can be found in the [SEEK v1.5.2 release notes](release-notes-1.5.2.html).
-  
+
 
 ## Version 1.5.1
 
@@ -808,9 +808,9 @@ Bugfix patch release that in particular fixes:
   * An error that prevented people entries being deleted in some cases.
   * An error turning exception emails on or off in the admin settings
   * An error that prevented a Programme submission being rejected
-  
+
 A full list of changes included in this release can be found in the [SEEK v1.5.1 release notes](release-notes-1.5.1.html).
-  
+
 
 ## Version 1.5.0
 
@@ -818,17 +818,17 @@ Release date: _December 11th 2017_
 
 This is quite a large release, and the main highlights include:
 
-  * Our first released version of our **JSON API**. This has been built to conform to the [JSON API](https://jsonapi.org) specification, 
+  * Our first released version of our **JSON API**. This has been built to conform to the [JSON API](https://jsonapi.org) specification,
     and is documented on [SwaggerHub](https://app.swaggerhub.com/apis/FAIRDOM/SEEK/0.1).
     This read API has been developed in conjuction with, and feeds into, a write API which will be released incrementally
-    in subsequent releases. For more details please read [API](/help/user-guide/api.html).
-  * Incorporating the new **[JERM 2 ontology](https://jermontology.org)**, along with updates and extensions to the RDF produced by 
+    in subsequent releases. For more details please read [API]({{ site.baseurl }}/help/user-guide/api.html).
+  * Incorporating the new **[JERM 2 ontology](https://jermontology.org)**, along with updates and extensions to the RDF produced by
     SEEK.
-  * **Migrated legacy sharing permissions**: Given registration for SEEK is open to anyone, 
-  we have removed the ability to administer sharing permissions of items for _“all registered users”_. 
-  This ability was removed from the user interface several versions ago, but a number of items retained this legacy sharing permission. 
-  Items shared with “all registered users” have now been updated so that their sharing permission is “project wide” instead, according to the projects the item is associated with. 
-  This restricts the audience which can interact with the item. 
+  * **Migrated legacy sharing permissions**: Given registration for SEEK is open to anyone,
+  we have removed the ability to administer sharing permissions of items for _“all registered users”_.
+  This ability was removed from the user interface several versions ago, but a number of items retained this legacy sharing permission.
+  Items shared with “all registered users” have now been updated so that their sharing permission is “project wide” instead, according to the projects the item is associated with.
+  This restricts the audience which can interact with the item.
   Owners and managers of items are still free to continue to choose and change the sharing permissions as they wish.
   * If users wish to **request to join a project**, but do not know the user that administers it, there is now a button available to do so. A message
   will be sent the administrators of those projects with additional details. When added to a project, the new member is automatically notified
@@ -862,15 +862,15 @@ Other major changes are included below:
   * Upgrade to Rails 4 platform
   * Project sharing permission defaults for when adding new items for a Project.
   * Events are included in the ISA graph, and the text formatting has been improved
-  * More descriptive tab titles  
-  
-There have also been many bug fixes (although many of the bugs listed in the release notes relate to problems 
-encountered during the Rails upgrade)        
+  * More descriptive tab titles
+
+There have also been many bug fixes (although many of the bugs listed in the release notes relate to problems
+encountered during the Rails upgrade)
 
 _(A future upgrade to Rails 5 is planned for the future once that version has stabalised and our dependencies have
 been updated)_
-  
-A full list of changes included in this release can be found in the [SEEK v1.4.0 release notes](release-notes-1.4.0.html).  
+
+A full list of changes included in this release can be found in the [SEEK v1.4.0 release notes](release-notes-1.4.0.html).
 
 
 ## Version 1.2.3, 1.3.3
@@ -889,8 +889,8 @@ Patch release that fixes some bugs, in particular:
   * Fix to displaying samples or sample types linked to a large number of projects or other associated items
   * Clarifies publication authors when the person that registers it is not an actual author
   * Fix for when using older version of Sqlite3
-  
-A full list of changes included in this release can be found in the [SEEK v1.3.2 release notes](release-notes-1.3.2.html).  
+
+A full list of changes included in this release can be found in the [SEEK v1.3.2 release notes](release-notes-1.3.2.html).
 
 ## Version 1.3.1
 
@@ -901,7 +901,7 @@ Patch release that fixes a few small bugs, in particular:
   * Fix to sharing form for Studies and Assays
   * Fix searching error where a spreadsheet was incorrectly expected
   * Fix selection of default license for a project
-  * Fixes related to strains and extracting sample strains 
+  * Fixes related to strains and extracting sample strains
 
 A full list of changes included in this release can be found in the [SEEK v1.3.1 release notes](release-notes-1.3.1.html).
 
@@ -909,7 +909,7 @@ A full list of changes included in this release can be found in the [SEEK v1.3.1
 
 Release date: _March 17th 2017_
 
-![new_sharing_matrix](/images/release-notes/openbis.png)
+![new_sharing_matrix]({{ site.baseurl }}/images/release-notes/openbis.png)
 
 This is the first public release that supports [openBIS](https://openbis.ch/) integration. This version includes
 
@@ -918,16 +918,16 @@ This is the first public release that supports [openBIS](https://openbis.ch/) in
   * Browse and download individual DataSet files, or download as a whole zip file.
   * Search indexing of registered openBIS DataSets
   * Automatic synchronisation with openBIS spaces and DataSets
-  * An [openSEEK bundle](/tech/openseek.html) that provides both SEEK and openBIS through Docker and Docker Compose.
+  * An [openSEEK bundle]({{ site.baseurl }}/tech/openseek.html) that provides both SEEK and openBIS through Docker and Docker Compose.
   * A new UI for setting sharing permissions
-    * Now displays a matrix for easier setting and viewing of individual permissions, replacing the pre-canned options 
+    * Now displays a matrix for easier setting and viewing of individual permissions, replacing the pre-canned options
     that weren't always that intuitive or logical.
-    
-![new_sharing_matrix](/images/release-notes/sharing-1.3.0.png){:.screenshot}
 
-Details on how to use openBIS with SEEK is available in our [User Guide](/help/user-guide/openbis.html)
-    
-A full list of changes included in this release can be found in the [SEEK v1.3.0 release notes](release-notes-1.3.0.html).    
+![new_sharing_matrix]({{ site.baseurl }}/images/release-notes/sharing-1.3.0.png){:.screenshot}
+
+Details on how to use openBIS with SEEK is available in our [User Guide]({{ site.baseurl }}/help/user-guide/openbis.html)
+
+A full list of changes included in this release can be found in the [SEEK v1.3.0 release notes]({{ site.baseurl }}/release-notes-1.3.0.html).
 
 ## Version 1.2.2
 
@@ -935,8 +935,8 @@ Release date: _March 3rd 2017_
 
 Fixes a couple of issues caused by some missing CSS (Stylesheet) elements related to Samples. Although minor this
  affected some of the functional behaviour.
-  
-A full list of changes included in this release can be found in the [SEEK v1.2.2 release notes](release-notes-1.2.2.html).  
+
+A full list of changes included in this release can be found in the [SEEK v1.2.2 release notes](release-notes-1.2.2.html).
 
 ## Version 1.2.1
 
@@ -948,9 +948,9 @@ Small bug fix release to fix:
   * Better DOI and Pubmed validation
   * Manual entry of publications currently disabled
   * Further improvements to authorization caching update speed and fix a small inconsistency with incomplete user registrations
-  
-A full list of changes included in this release can be found in the [SEEK v1.2.1 release notes](release-notes-1.2.1.html).  
-    
+
+A full list of changes included in this release can be found in the [SEEK v1.2.1 release notes](release-notes-1.2.1.html).
+
 
 ## Version 1.2.0
 
@@ -961,43 +961,43 @@ Large update with many new features and improvements, in particular a new approa
   * A major reimplementation and design of our support for Samples
     * Developed as part of our discussions within the FAIRDOM-ELIXIR Samples Club, which was setup specifically to overcome problems with
      our old BioSamples
-    * Flexible system that allows users to design their own Sample Type standards, which are associated with an 
+    * Flexible system that allows users to design their own Sample Type standards, which are associated with an
     extractable spreadsheet template
       * Templates can be autogenerated, or Sample Types created from existing templates.
-      * Sample Types contain a user designed set of attributes, and attribute types. 
+      * Sample Types contain a user designed set of attributes, and attribute types.
       Validation is included to check a value matches its type, or if specified as ‘required’ a presence check is carried out.
       * Units can be optionally associated with a Sample Type attribute.
       * Sample Types can be interlinked, for example a Tissue Sample Type may link to a Patient Sample Type
-      * Samples can be added to SEEK according to sample type. They can either be added manually, or many can be 
+      * Samples can be added to SEEK according to sample type. They can either be added manually, or many can be
       extracted from an uploaded data file that originated from the associated template.
-      * An attribute can be linked to a controlled vocabulary which enforces a set of values. 
+      * An attribute can be linked to a controlled vocabulary which enforces a set of values.
       This also puts in place future support for CV’s from standard ontologies.
-    * Assays were updated to now represent the first of many future processes, which can receive and produce sets of samples. 
-    UI improvements were made to support easily associating many samples to an assay in at once. 
+    * Assays were updated to now represent the first of many future processes, which can receive and produce sets of samples.
+    UI improvements were made to support easily associating many samples to an assay in at once.
     A Process describes the changes a Sample may go through.
-    * This new framework now has possibility to support the SampleTab standard, allowing SEEK to deposit to the EBI Biosamples registry    
+    * This new framework now has possibility to support the SampleTab standard, allowing SEEK to deposit to the EBI Biosamples registry
     * A more flexible approach to handling Samples was an important requirement for full openBIS integration.
     * It is a framework that can be built upon and enhanced according to user needs in future versions.
-    * There is documentation available in our [SEEK Samples User Guide](/help/user-guide/samples.html)
-  * An improved Graphical and interactive ISA graph viewer. It now contains all details but expands as the user interacts 
-  with it, avoiding the problem of over-complex graphs. A tree view is also now available to navigate the graph, 
+    * There is documentation available in our [SEEK Samples User Guide]({{ site.baseurl }}/help/user-guide/samples.html)
+  * An improved Graphical and interactive ISA graph viewer. It now contains all details but expands as the user interacts
+  with it, avoiding the problem of over-complex graphs. A tree view is also now available to navigate the graph,
   which includes the Programmes and Projects. A full view of the graph is available if necessary.
-  * Authorization speedup. A significant improvement in speed and scale when updating the permissions of an item, 
-  or a person changing state (e.g. to a  new role or project). For performance reasons authorization is cached, which 
-  needs updating when a state changes. This resulted in a noticeable delay observed between users when permissions are changed 
-  (as a background task updates the cache), sometimes causing confusion. This delay has now been significantly reduced, 
+  * Authorization speedup. A significant improvement in speed and scale when updating the permissions of an item,
+  or a person changing state (e.g. to a  new role or project). For performance reasons authorization is cached, which
+  needs updating when a state changes. This resulted in a noticeable delay observed between users when permissions are changed
+  (as a background task updates the cache), sometimes causing confusion. This delay has now been significantly reduced,
   and the delay is not dependent on the number of items.
   * Support for [Docker](https://docker.com), along with documentation. Docker images are automatically built for
-   different versions and can be run either as a single container or multiple micro-services split across different containers. 
-  Handles upgrades and persistent data. Docker allows SEEK to be setup and run with a single command. This our expected 
+   different versions and can be run either as a single container or multiple micro-services split across different containers.
+  Handles upgrades and persistent data. Docker allows SEEK to be setup and run with a single command. This our expected
   approach to simple packaging of SEEK with openBIS.
-    * Documentation on using SEEK with Docker is available in our [Docker Guide](/tech/docker.html)
+    * Documentation on using SEEK with Docker is available in our [Docker Guide]({{ site.baseurl }}/tech/docker.html)
   * A Project administrator may now specify the default license for their project which is automatically selected when creating a new item, but can be changed by the user if necessary.
   * Improved usability of adding new Publications from a DOI or PubmedID
-  * Arbitrary URL schemes for remote files, that can be handled outside of SEEK. For example, and scp:// url could be 
+  * Arbitrary URL schemes for remote files, that can be handled outside of SEEK. For example, and scp:// url could be
   provided for and openSSH based resource
-  * Storage metrics in one place available to SEEK administrator, split by Project and Programme. 
-  Provides a single place to monitor storage rather than checking each Project page.  
+  * Storage metrics in one place available to SEEK administrator, split by Project and Programme.
+  Provides a single place to monitor storage rather than checking each Project page.
 
 
 A full list of changes included in this release can be found in the [SEEK v1.2.0 release notes](release-notes-1.2.0.html).
@@ -1032,7 +1032,7 @@ Release date: _June 15th 2016_
       * New logos for Investigation, Study and Assays
       * New logos badges for the different roles
   * Support for Programmes to define funding codes
-  * Licensing of assets. Existing assets will default to 'No License'. For more information please visit [Licenses](/help/user-guide/licenses.html)
+  * Licensing of assets. Existing assets will default to 'No License'. For more information please visit [Licenses]({{ site.baseurl }}/help/user-guide/licenses.html)
   * Ability to publish and create Research Object snapshots for Studies and Assays, along with assigning a DOI. Previously only the larger Investigation package was supported
   * Display storage usage information for Programmes and Projects, visible to administrators.
 
@@ -1110,14 +1110,14 @@ Release date: _December 8th 2015_
 * Biosample support has been deprecated and disabled.
 * Biosamples will be improved and reimplemented as our next major feature change.
 * Biosamples can be re-enabled by an administrator.
-* If you currently use the Biosamples that was available in SEEK please [contact us](/contacting-us.html).
+* If you currently use the Biosamples that was available in SEEK please [contact us]({{ site.baseurl }}/contacting-us.html).
 
 ### Help pages link
 
 * Help pages can now be hosted externally and an administrator can point to the source of them.
 * From past experience, we find it much easier to maintain and update our own Help pages and documentation outside of SEEK, allowing us to expand and improve on them between releases.
-* Our documentation will now be published and maintained using GitHub pages making it easier to maintain between versions and receive [Contributions](/tech/contributing).
-* Internal help pages are currently still available, but could be deprecated in a future release. If you edit your own internal pages please [contact us](/contacting-us).
+* Our documentation will now be published and maintained using GitHub pages making it easier to maintain between versions and receive [Contributions]({{ site.baseurl }}/tech/contributing).
+* Internal help pages are currently still available, but could be deprecated in a future release. If you edit your own internal pages please [contact us]({{ site.baseurl }}/contacting-us).
 
 ### Miscellaneous
 

--- a/tech/reporting-bugs-and-features.md
+++ b/tech/reporting-bugs-and-features.md
@@ -3,13 +3,13 @@ title: Reporting Bugs and raising Feature Requests
 ---
 
 
-You can report bugs or request new features using the any of the [methods to contact us](/contacting-us). Preferably submit a [GitHub issue](https://fair-dom.org/issues).
+You can report bugs or request new features using the any of the [methods to contact us]({{ site.baseurl }}/contacting-us). Preferably submit a [GitHub issue](https://fair-dom.org/issues).
 
 First check [Existing Issues](https://fair-dom.org/issues) in order to see if your planned contribution is new.
 
 If you find a feature or bug has already been reported, please don't let this deter you from reporting it yourself. Doing so will help prioritise issues.
 
-If you can contribute to fix or add the feature, please read our [Contributors guides](/tech/contributing). If you are planning on contributing a feature or bug fix, it is still
+If you can contribute to fix or add the feature, please read our [Contributors guides]({{ site.baseurl }}/tech/contributing). If you are planning on contributing a feature or bug fix, it is still
 advisable to discuss it with us first, as it may be something that is already being worked on and we would want to avoid wasted effort.
 
 Generally please provide the following information:

--- a/tech/roadmap.md
+++ b/tech/roadmap.md
@@ -7,7 +7,7 @@ redirect_from: "/roadmap.html"
 
 This is an outline of plans the core FAIRDOM-SEEK development team will be working on in the near future.
 
-It is an overview of the main priorities, and milestones. FAIRDOM-SEEK is developed following an Agile development process, meaning some of the features and timing may change - however, these items are very high in our priorities. 
+It is an overview of the main priorities, and milestones. FAIRDOM-SEEK is developed following an Agile development process, meaning some of the features and timing may change - however, these items are very high in our priorities.
 
 They are expected to be added to FAIRDOM-SEEK in roughly the order they are presented here.
 
@@ -28,7 +28,7 @@ They are expected to be added to FAIRDOM-SEEK in roughly the order they are pres
 
 <br/>
 
-Please also see the [WorkflowHub Roadmap](https://about.workflowhub.eu/roadmap/), 
+Please also see the [WorkflowHub Roadmap](https://about.workflowhub.eu/roadmap/),
 which is being built on and in conjunction with FAIRDOM-SEEK.
 
 ---
@@ -37,7 +37,7 @@ which is being built on and in conjunction with FAIRDOM-SEEK.
 
 These are completed Roadmap features, and includes the version of SEEK the feature was included in.
 
-You can find more details about each release in our [Change Logs](/tech/releases/)
+You can find more details about each release in our [Change Logs]({{ site.baseurl }}/tech/releases/)
 
 
 | Feature                                                                              | SEEK version |

--- a/tech/useful-links.md
+++ b/tech/useful-links.md
@@ -12,9 +12,9 @@ SEEK Issue tracking: [https://fair-dom.org/issues](https://fair-dom.org/issues)
 
 SEEK software website: [https://seek4science.org](https://seek4science.org)
 
-SEEK installation guide: [/tech/install](/tech/install)
+SEEK installation guide: [/tech/install]({{ site.baseurl }}/tech/install)
 
-SEEK changelog: [/tech/releases/](/tech/releases)
+SEEK changelog: [/tech/releases/]({{ site.baseurl }}/tech/releases)
 
 JERM ontology: [https://jermontology.org](https://jermontology.org)
 


### PR DESCRIPTION
When using a `baseurl` in [_config.yml](https://github.com/seek4science/seek-documentation/blob/main/_config.yml), links to an absolute path (mostly images) do not resolve.

This will fix deployments of the documentation under a sub-URI.