### PR TITLE
Enabled breadcrumb feature of ETT

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,6 +51,7 @@ theme_variables:
   # toc:
   #   min_headings: 2
   #   headings: 'h2'
+  breadcrumb: true
   topnav:
     theme: light
     brand_logo: images/fairdom-seek-docs-logo.svg


### PR DESCRIPTION
Fixes #62, enable the breadcrumb in base SEEK docs, as seen in DataHub docs. It picks the file structure and shows one of these four forms:

Pattern | Where
---|---
🏠 > Get FAIRDOM-SEEK | For the Get SEEK page
🏠 > Help > [page title]   |  For archived help pages
🏠 > Help > User Guide > [page title] |  For user guide pages
🏠 > FAIRDOM-SEEK Technical Guide > [page title] | For technical guide pages
[nothing] | For the homepage

Some examples of it:

<img width="1318" height="478" alt="image" src="https://github.com/user-attachments/assets/5fa0fd2f-2b61-458e-a4a8-ad7781ab4e32" />

<img width="1318" height="478" alt="image" src="https://github.com/user-attachments/assets/e1fefc22-0867-402d-a8a1-36dad56a66da" />

<img width="1318" height="478" alt="image" src="https://github.com/user-attachments/assets/77899681-9508-4c37-8a8b-592259a75bb5" />

<img width="1318" height="478" alt="image" src="https://github.com/user-attachments/assets/46f87f0e-1307-40d6-8bd8-68ed23a5efcb" />

<img width="1318" height="478" alt="image" src="https://github.com/user-attachments/assets/1ed1285d-ec70-48d2-98fc-436e68f11ca8" />

<img width="1318" height="478" alt="image" src="https://github.com/user-attachments/assets/3322a4e0-b5da-4260-a109-a69172708dfa" />

<img width="1318" height="478" alt="image" src="https://github.com/user-attachments/assets/025f0bbb-b30c-42c5-93fd-1aa17a9e778d" />

<img width="1318" height="478" alt="image" src="https://github.com/user-attachments/assets/a9683945-0a18-406a-8f43-ba75dd8ca18a" />

<img width="1318" height="478" alt="image" src="https://github.com/user-attachments/assets/e249b71c-546e-48bc-9ea3-1551ad224e0f" />

Is this an improvement? Does it help? Note, there are no other configurations offered by ETT. 