### PR TITLE
Update Solr setup and configuration docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,8 +2,8 @@
 
 remote_theme: ELIXIR-Belgium/elixir-toolkit-theme@6.0.0
 
-current_seek_version: "1.17.4"
-current_docker_tag: "1.17"
+current_seek_version: "1.18.0"
+current_docker_tag: "1.18"
 
 plugins:
   - jekyll-sitemap

--- a/tech/docker/docker-compose.md
+++ b/tech/docker/docker-compose.md
@@ -153,14 +153,19 @@ docker compose up -d
 
 {% include callout.html type="warning" content="From version 1.18.0, the `solr/seek/conf/` directory from the SEEK source is required alongside `docker-compose.yml`. If you are upgrading from an earlier version, ensure this directory is present before restarting." %}
 
-When the Solr configuration changes between SEEK versions, the existing index data must be cleared and rebuilt. Since the configuration is mounted directly from the SEEK repository, no image update is needed. Bring the stack down, remove and recreate the Solr data volume, then restart and reindex:
+When the Solr configuration changes between SEEK versions, the existing index data must be cleared and rebuilt. Since the configuration is mounted directly from the SEEK repository, no image update is needed — you just need an up-to-date copy of the `solr/seek/conf/` directory for the version you are updating to. Bring the stack down, remove and recreate the Solr data volume, then restart and reindex:
 
 ```bash
 docker compose down
 docker volume rm seek-solr-data
 docker volume create --name=seek-solr-data
 docker compose up -d
-docker exec seek bundle exec rake seek:reindex_all
+```
+
+Wait for the seek container to finish starting (you can monitor with `docker compose logs seek`), then reindex:
+
+```bash
+docker compose exec seek bundle exec rake seek:reindex_all
 ```
 
 ## Moving from a standalone installation to Docker Compose

--- a/tech/docker/docker-compose.md
+++ b/tech/docker/docker-compose.md
@@ -10,7 +10,7 @@ You will first need [Docker installed](docker-install.html)
 
 See the [Docker Compose Installation Guide](https://docs.docker.com/compose/install/) for how to install Docker Compose.
 
-Once installed, all that is needed are the [docker-compose.yml](https://raw.githubusercontent.com/seek4science/seek/seek-{{ site.current_docker_tag }}/docker-compose.yml) and the [docker/db.env](https://raw.githubusercontent.com/seek4science/seek/seek-{{ site.current_docker_tag }}/docker/db.env) files,
+Once installed, all that is needed are the [docker-compose.yml](https://raw.githubusercontent.com/seek4science/seek/seek-{{ site.current_docker_tag }}/docker-compose.yml) and the [docker/db.env](https://raw.githubusercontent.com/seek4science/seek/seek-{{ site.current_docker_tag }}/docker/db.env) files, along with the [solr/seek/conf/](https://github.com/seek4science/seek/tree/seek-{{ site.current_docker_tag }}/solr/seek/conf) directory,
 although you can simply check out the SEEK source from GitHub - see [Getting SEEK](../install.html#getting-seek). You would be advised to change the passwords in the *db.env* file.
 
 First you need to create 4 volumes
@@ -150,6 +150,8 @@ docker compose up -d
 ```
 
 ## Updating the Solr Configuration
+
+{% include callout.html type="warning" content="From version 1.18.0, the `solr/seek/conf/` directory from the SEEK source is required alongside `docker-compose.yml`. If you are upgrading from an earlier version, ensure this directory is present before restarting." %}
 
 When the Solr configuration changes between SEEK versions, the existing index data must be cleared and rebuilt. Since the configuration is mounted directly from the SEEK repository, no image update is needed. Bring the stack down, remove and recreate the Solr data volume, then restart and reindex:
 

--- a/tech/docker/docker-compose.md
+++ b/tech/docker/docker-compose.md
@@ -149,6 +149,19 @@ docker compose down
 docker compose up -d
 ```
 
+## Updating the Solr Configuration
+
+When the Solr schema changes between SEEK versions, the existing index data must be cleared and rebuilt. Pull the updated `fairdom/seek-solr:8.11` image, remove and recreate the Solr data volume, then restart and reindex:
+
+```bash
+docker compose pull solr
+docker compose down
+docker volume rm seek-solr-data
+docker volume create --name=seek-solr-data
+docker compose up -d
+docker exec seek bundle exec rake seek:reindex_all
+```
+
 ## Moving from a standalone installation to Docker Compose
 
 If you have an existing SEEK installation running on "Bare Metal" and would like to move to using Docker compose, we have a script that can help migrate the data. The script was created to help move some of our own services, but hasn't been heavily tested beyond that so please use with care. Please feel free to [Contribute](../contributing-to-seek) any improvements.

--- a/tech/docker/docker-compose.md
+++ b/tech/docker/docker-compose.md
@@ -151,10 +151,9 @@ docker compose up -d
 
 ## Updating the Solr Configuration
 
-When the Solr schema changes between SEEK versions, the existing index data must be cleared and rebuilt. Pull the updated `fairdom/seek-solr:8.11` image, remove and recreate the Solr data volume, then restart and reindex:
+When the Solr configuration changes between SEEK versions, the existing index data must be cleared and rebuilt. Since the configuration is mounted directly from the SEEK repository, no image update is needed. Bring the stack down, remove and recreate the Solr data volume, then restart and reindex:
 
 ```bash
-docker compose pull solr
 docker compose down
 docker volume rm seek-solr-data
 docker volume create --name=seek-solr-data

--- a/tech/setting-up-solr.md
+++ b/tech/setting-up-solr.md
@@ -102,6 +102,25 @@ Solr is now setup, and you can trigger jobs to reindex the content with
 bundle exec rake seek:reindex_all
 ```
 
+## Updating the Solr Configuration
+
+When the Solr configuration changes between SEEK versions, the existing index data must be cleared and rebuilt to remain consistent with the new configuration.
+
+Copy the updated configuration from your SEEK installation into the Solr data directory, clear the existing index data, then restart the service. Run the following from the root of your SEEK installation (in this example /srv/rails/seek):
+
+```bash
+sudo service solr stop
+sudo cp -r solr/seek/conf/ /var/solr/data/seek/conf/
+sudo rm -rf /var/solr/data/seek/data/
+sudo service solr start
+```
+
+Once running, trigger a full reindex:
+
+```bash
+bundle exec rake seek:reindex_all
+```
+
 
 
 

--- a/tech/setting-up-solr.md
+++ b/tech/setting-up-solr.md
@@ -117,7 +117,7 @@ This will stop and remove the existing container, clear the index data, start a 
 
 ### Direct Installation
 
-Delete and recreate the core using the Solr CLI, then trigger a full reindex. Run the following from the root of your SEEK installation (in this example /srv/rails/seek):
+Ensure the Solr service is running, then delete and recreate the core using the Solr CLI and trigger a full reindex. The `solr delete` and `solr create` commands require a running Solr instance. Run the following from the root of your SEEK installation (in this example /srv/rails/seek):
 
 ```bash
 cp -r solr/seek/conf /tmp/seek-solr-conf

--- a/tech/setting-up-solr.md
+++ b/tech/setting-up-solr.md
@@ -88,6 +88,7 @@ and to avoid file permission issue copy the `solr` directory to a location where
 cd /srv/rails/seek
 cp -r solr /tmp/seek-solr
 sudo su - solr -c "/opt/solr/bin/solr create -c seek -d /tmp/seek-solr/seek/conf"
+rm -rf /tmp/seek-solr
 ```
 
 The configuration and data for the SEEK core can be found in _/var/solr/data/seek_ .

--- a/tech/setting-up-solr.md
+++ b/tech/setting-up-solr.md
@@ -121,6 +121,7 @@ Copy the updated configuration from your SEEK installation into the Solr data di
 ```bash
 sudo service solr stop
 sudo cp -r solr/seek/conf/ /var/solr/data/seek/conf/
+sudo chown -R solr:solr /var/solr/data/seek/conf/
 sudo rm -rf /var/solr/data/seek/data/
 sudo service solr start
 ```

--- a/tech/setting-up-solr.md
+++ b/tech/setting-up-solr.md
@@ -13,34 +13,32 @@ image. If this is not possible, there are also some instructions below on direct
 
 ## Using the Docker Image
 
-Using Docker provides the easiest solution to running Solr, pre-configured for SEEK, using the same _fairdom/seek-solr:8.11_
-image that we use with Docker compose.
+Using Docker provides the easiest solution to running Solr for SEEK, using the official _solr:8.11.4_ image. The SEEK-specific configuration is mounted directly from your installation directory, so any configuration updates are automatically picked up when the container is restarted.
 
-You first need to have [Docker installed](docker/docker-install). We provide example scripts for setting up and starting, as well as 
-stopping the Solr service: 
+You first need to have [Docker installed](docker/docker-install). We provide example scripts for managing the Solr service, which should be run from the root directory of your SEEK installation:
 
   * [script/start-docker-solr.sh](https://github.com/seek4science/seek/blob/v{{ site.current_seek_version }}/script/start-docker-solr.sh)
-    * When first executed this will fetch the image, and create a volume to persist the indexed data, and start the service. It is set to automatically restart
-      unless explicitly stopped. On subsequent runs it will restart the service.
+    * Creates and starts the container, mounting the SEEK configuration from your installation directory. Creates the data volume if it does not already exist. Waits until Solr is ready before returning.
   * [script/stop-docker-solr.sh](https://github.com/seek4science/seek/blob/v{{ site.current_seek_version }}/script/stop-docker-solr.sh)
-    * As is suggests, this will stop the service. The container and volume will remain, ready to be restarted.
+    * Stops and removes the container. The data volume is preserved, so the index persists.
+  * [script/reset-docker-solr.sh](https://github.com/seek4science/seek/blob/v{{ site.current_seek_version }}/script/reset-docker-solr.sh)
+    * Stops and removes the container, deletes and recreates the data volume, starts Solr, and runs a full reindex. Use this when the Solr configuration has changed and the index needs to be rebuilt.
+  * [script/delete-docker-solr.sh](https://github.com/seek4science/seek/blob/v{{ site.current_seek_version }}/script/delete-docker-solr.sh)
+    * Removes both the container and the data volume entirely.
 
-These scripts should be run from the root directory of your SEEK installation, e.g:
+e.g. to start:
 
 ```bash
 sh ./script/start-docker-solr.sh
 ```
 
-The Docker container will be named _seek-solr_ and the volume named _seek-solr-data-volume_ .
+The Docker container will be named _seek-search_ and the volume named _seek-solr-data-volume_.
 
 Once running, and with search enabled, you can trigger jobs to reindex all searchable content with
 
 ```bash
 bundle exec rake seek:reindex_all
 ```
-
-There is an additional script, [script/delete-docker-solr.sh](https://github.com/seek4science/seek/blob/v{{ site.current_seek_version }}/script/delete-docker-solr.sh), 
-that can be used to delete both the container and volume.
 
 ## Installing Apache Solr
 
@@ -105,6 +103,18 @@ bundle exec rake seek:reindex_all
 ## Updating the Solr Configuration
 
 When the Solr configuration changes between SEEK versions, the existing index data must be cleared and rebuilt to remain consistent with the new configuration.
+
+### Using the Docker Image
+
+Since the configuration is mounted directly from your SEEK installation, no image update is required. Run the following from the root of your SEEK installation:
+
+```bash
+sh ./script/reset-docker-solr.sh
+```
+
+This will stop and remove the existing container, clear the index data, start a fresh container with the updated configuration, and trigger a full reindex automatically.
+
+### Direct Installation
 
 Copy the updated configuration from your SEEK installation into the Solr data directory, clear the existing index data, then restart the service. Run the following from the root of your SEEK installation (in this example /srv/rails/seek):
 

--- a/tech/setting-up-solr.md
+++ b/tech/setting-up-solr.md
@@ -117,7 +117,7 @@ This will stop and remove the existing container, clear the index data, start a 
 
 ### Direct Installation
 
-Ensure the Solr service is running, then delete and recreate the core using the Solr CLI and trigger a full reindex. The `solr delete` and `solr create` commands require a running Solr instance. Run the following from the root of your SEEK installation (in this example /srv/rails/seek):
+Ensure the Solr service is running, then delete and recreate the core using the Solr CLI and trigger a full reindex. Run the following from the root of your SEEK installation (in this example /srv/rails/seek):
 
 ```bash
 cp -r solr/seek/conf /tmp/seek-solr-conf

--- a/tech/setting-up-solr.md
+++ b/tech/setting-up-solr.md
@@ -116,21 +116,17 @@ This will stop and remove the existing container, clear the index data, start a 
 
 ### Direct Installation
 
-Copy the updated configuration from your SEEK installation into the Solr data directory, clear the existing index data, then restart the service. Run the following from the root of your SEEK installation (in this example /srv/rails/seek):
+Delete and recreate the core using the Solr CLI, then trigger a full reindex. Run the following from the root of your SEEK installation (in this example /srv/rails/seek):
 
 ```bash
-sudo service solr stop
-sudo cp -r solr/seek/conf/ /var/solr/data/seek/conf/
-sudo chown -R solr:solr /var/solr/data/seek/conf/
-sudo rm -rf /var/solr/data/seek/data/
-sudo service solr start
-```
-
-Once running, trigger a full reindex:
-
-```bash
+cp -r solr/seek/conf /tmp/seek-solr-conf
+sudo su - solr -c "/opt/solr/bin/solr delete -c seek"
+sudo su - solr -c "/opt/solr/bin/solr create -c seek -d /tmp/seek-solr-conf"
 bundle exec rake seek:reindex_all
+rm -rf /tmp/seek-solr-conf
 ```
+
+The config is copied to `/tmp` first so that the `solr` user can read it. Deleting the core also removes the existing index data, so a full reindex is required afterwards.
 
 
 


### PR DESCRIPTION
Closes #89

Updates the Solr documentation to reflect the changes introduced in seek4science/seek#2605 and seek4science/seek#2488.

## Changes

**`tech/setting-up-solr.md`**
- Updated Docker image section to reflect the switch to the official `solr:8.11.4` image with config mounted from the installation directory, corrects the container name, and documents all four management scripts including the new `reset-docker-solr.sh`
- Added `/tmp` cleanup to the direct install steps
- New "Updating the Solr Configuration" section covering both the Docker image path (via `reset-docker-solr.sh`) and the direct install path (using `solr delete`/`solr create` to avoid file permission issues)

**`tech/docker/docker-compose.md`**
- Noted `solr/seek/conf/` as a required file alongside `docker-compose.yml` and `db.env` in the initial setup, with a link to GitHub
- New "Updating the Solr Configuration" section with a warning callout that `solr/seek/conf/` is required from version 1.18.0, and steps to clear the Solr volume and reindex

Note: links to these update steps from the main upgrade guide will be added in a later change.